### PR TITLE
[ 📌 FEAT] 게시글 작성 구현

### DIFF
--- a/kakaobase/src/app/post/new/page.tsx
+++ b/kakaobase/src/app/post/new/page.tsx
@@ -1,7 +1,11 @@
+import Header from '@/components/common/header/Header';
+import PostEditor from '@/components/post/PostEditor';
+
 export default function Page() {
   return (
-    <div>
-      <div>게시글 작성 페이지입니다.</div>
+    <div className="flex flex-col h-screen">
+      <Header label="게시글 작성" />
+      <PostEditor />
     </div>
   );
 }

--- a/kakaobase/src/components/post/PostEditor.tsx
+++ b/kakaobase/src/components/post/PostEditor.tsx
@@ -1,7 +1,162 @@
-export default function PostEditor() {
+'use client';
+
+import { Image, Youtube } from 'lucide-react';
+import SubmitButton from '../common/SubmitButton';
+import { NewPostData, usePostEditorForm } from '@/hooks/post/usePostEditorForm';
+import { useEffect, useState } from 'react';
+import SubmitButtonSmall from '../common/SubmitButtonSmall';
+import {
+  FieldErrors,
+  UseFormRegister,
+  UseFormSetValue,
+  UseFormWatch,
+} from 'react-hook-form';
+
+function HelperText({ errorMessage }: { errorMessage: string }) {
+  return <div className="text-redHeart text-xs h-4">{errorMessage}</div>;
+}
+
+function ContentInput({
+  register,
+  errors,
+}: {
+  register: UseFormRegister<NewPostData>;
+  errors: FieldErrors<NewPostData>;
+}) {
+  //로그인을 가정한 임시 사용자
+  const nickname = 'daisy.kim';
+
   return (
-    <div>
-      <div>게시글 작성 폼 컴포넌트</div>
+    <div className="w-full">
+      <div className="text-md font-bold">{nickname}</div>
+
+      <textarea
+        {...register('content')}
+        placeholder="지금 무슨 일이 발생하고 있나요?"
+        className="w-full focus:outline-none bg-transparent text-xs resize-none max-h-60"
+        rows={1}
+        onInput={(e) => {
+          e.currentTarget.style.height = 'auto';
+          e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`;
+        }}
+      />
+
+      <HelperText errorMessage={errors.content?.message || ''} />
+    </div>
+  );
+}
+
+function YoutubeInput({
+  errors,
+  register,
+}: {
+  errors: FieldErrors<NewPostData>;
+  register: UseFormRegister<NewPostData>;
+}) {
+  return (
+    <div className="w-full">
+      <div className="flex gap-2 font-bold">
+        <Youtube />
+        <div className="text-md font-bold">유튜브 링크</div>
+      </div>
+      <input
+        {...register('youtubeUrl')}
+        placeholder="유튜브 링크를 입력하세요."
+        className="w-full focus:outline-none bg-transparent text-xs"
+      />
+      <HelperText errorMessage={errors.youtubeUrl?.message || ''} />
+    </div>
+  );
+}
+
+function ImageInput({
+  setValue,
+  errors,
+  watch,
+}: {
+  errors: FieldErrors<NewPostData>;
+  setValue: UseFormSetValue<NewPostData>;
+  watch: UseFormWatch<NewPostData>;
+}) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const imageFile = watch('imageFile');
+
+  useEffect(() => {
+    if (imageFile && imageFile instanceof File) {
+      const url = URL.createObjectURL(imageFile);
+      setPreviewUrl(url);
+      return () => URL.revokeObjectURL(url);
+    }
+  }, [imageFile]);
+  return (
+    <div className="w-full">
+      <label className="flex gap-2 items-center cursor-pointer">
+        <Image />
+        <div className="text-xs px-4 py-1 bg-myLightBlue w-40 text-center rounded-full text-textOnLight">
+          이미지 업로드
+        </div>
+        <input
+          type="file"
+          accept="image/png, image/jpeg, image/jpg, image/webp"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) {
+              setValue('imageFile', file, { shouldValidate: true });
+            }
+          }}
+        />
+      </label>
+
+      {/* 이미지 미리보기 */}
+      {previewUrl && (
+        <div className="mt-2 flex flex-col gap-2">
+          <img
+            src={previewUrl}
+            alt="미리보기"
+            className="rounded-sm max-w-full"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              setPreviewUrl(null);
+              setValue('imageFile', undefined, { shouldValidate: true });
+            }}
+            className="text-xs w-fit rounded-full text-redHeart underline"
+          >
+            사진 삭제
+          </button>
+        </div>
+      )}
+      <HelperText errorMessage={errors.imageFile?.message || ''} />
+    </div>
+  );
+}
+
+export default function PostEditor() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    onSubmit,
+    watch,
+    setValue,
+  } = usePostEditorForm();
+
+  return (
+    <div className="w-full h-full flex justify-center">
+      <div className="flex flex-col justify-between items-center h-full w-full py-10 text-textColor">
+        <div className="flex flex-col gap-6 w-full px-12">
+          <ContentInput errors={errors} register={register} />
+          <YoutubeInput errors={errors} register={register} />
+          <ImageInput errors={errors} watch={watch} setValue={setValue} />
+        </div>
+        <SubmitButton
+          text="게시글 업로드"
+          onClick={handleSubmit(onSubmit)}
+          disabled={!isValid}
+        />
+      </div>
     </div>
   );
 }

--- a/kakaobase/src/data/newDummyPost.tsx
+++ b/kakaobase/src/data/newDummyPost.tsx
@@ -1,0 +1,27 @@
+import { PostState } from '@/stores/postStore';
+
+export const newDummyPost: PostState = {
+  id: 100,
+  userId: 12,
+  nickname: 'roro.han',
+  userProfileUrl: '/test_profile.jpg',
+  isMine: true,
+  type: 'post',
+  content: '임시 작성한 새 게시글입니다.',
+  ImageUrl: '',
+  youtubeUrl: 'EjjaEtWd4Tg',
+  youtubeSummary: '임시 게시글 생성 테스트입니다. (더미 데이터)',
+  commentCount: 0,
+  likeCount: 0,
+  isFollowing: false,
+  isLiked: false,
+  createdAt: new Date().toISOString(),
+  onClickFollow: () => console.log('팔로우'),
+  onClickReport: () => console.log('신고'),
+  onClickUser: () => console.log('유저 클릭'),
+  onClickPostCard: () => console.log('포스트 카드 클릭'),
+  onClickDelete: () => console.log('삭제'),
+  onClickLike: () => console.log('좋아요'),
+  onClickYoutubeSummary: () => console.log('요약 보기'),
+  setPostCardInfo: (post) => console.log('포스트 정보 업데이트:', post),
+};

--- a/kakaobase/src/hooks/post/usePostCardDetail.tsx
+++ b/kakaobase/src/hooks/post/usePostCardDetail.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react';
 import getPosts from '@/apis/postList';
 import { PostState } from '@/stores/postStore';
-import { useRouter } from 'next/navigation';
+import { newDummyPost } from '@/data/newDummyPost';
 
 export default function usePostDetail({ id }: { id: number }) {
-  const router = useRouter();
-
   const [post, setPost] = useState<PostState>();
   //const postType = 'pangyo_2';
 
@@ -15,6 +13,10 @@ export default function usePostDetail({ id }: { id: number }) {
   const fetchPosts = async () => {
     try {
       setLoading(true);
+      if (id == 100) {
+        setPost(newDummyPost);
+        return;
+      }
       const data = await getPosts({});
       setPost(data.find((post) => post.id === id));
     } catch (err) {

--- a/kakaobase/src/hooks/post/usePostEditorForm.tsx
+++ b/kakaobase/src/hooks/post/usePostEditorForm.tsx
@@ -1,0 +1,70 @@
+import { postSchema } from '@/schemas/postSchema';
+import { usePostStore } from '@/stores/postStore';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+export type NewPostData = z.infer<typeof postSchema>;
+
+// async function uploadToS3(file: File): Promise<string> {
+//   const res = await fetch('/api/presigned-url', {
+//     method: 'POST',
+//     body: JSON.stringify({ filename: file.name, type: file.type }),
+//     headers: { 'Content-Type': 'application/json' },
+//   });
+//   const { url } = await res.json();
+
+//   await fetch(url, {
+//     method: 'PUT',
+//     headers: { 'Content-Type': file.type },
+//     body: file,
+//   });
+
+//   return url.split('?')[0];
+// }
+
+export const usePostEditorForm = () => {
+  const router = useRouter();
+  const content = usePostStore((state) => state.content);
+  const youtubeUrl = usePostStore((state) => state.youtubeUrl);
+  const imageUrl = usePostStore((state) => state.imageUrl);
+  const setEditorData = usePostStore((state) => state.setEditorData);
+
+  const methods = useForm<NewPostData>({
+    resolver: zodResolver(postSchema),
+    mode: 'all',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      content: '',
+      youtubeUrl: '',
+      imageFile: undefined,
+    },
+  });
+
+  const onSubmit = async (data: NewPostData) => {
+    let uploadedUrl = '';
+    // if (data.imageFile) {
+    //   uploadedUrl = await uploadToS3(data.imageFile);
+    // }
+
+    const newPostId = 100;
+
+    setEditorData({
+      content: data.content ?? '',
+      youtubeUrl: data.youtubeUrl ?? '',
+      imageUrl: uploadedUrl,
+    });
+
+    router.push(`/post/${newPostId}`);
+  };
+
+  return {
+    ...methods,
+    onSubmit,
+    imageUrl,
+    youtubeUrl,
+    content,
+    setValue: methods.setValue,
+  };
+};

--- a/kakaobase/src/schemas/postSchema.tsx
+++ b/kakaobase/src/schemas/postSchema.tsx
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const postSchema = z
+  .object({
+    content: z
+      .string()
+      .max(2000, { message: '최대 2000자까지만 입력할 수 있습니다.' })
+      .optional(),
+    youtubeUrl: z
+      .string()
+      .optional()
+      .refine((val) => !val || val.startsWith('https://www.youtube.com/'), {
+        message: '유튜브 링크 형식이 올바르지 않습니다.',
+      }),
+    imageFile: z
+      .instanceof(File)
+      .optional()
+      .refine((file) => !file || /\.(png|jpeg|jpg|webp)$/i.test(file.name), {
+        message: '이미지 파일 형식은 png, jpg, jpeg, webp만 가능합니다.',
+      }),
+  })
+  .superRefine((data, ctx) => {
+    const { youtubeUrl, imageFile, content } = data;
+
+    // 1. 둘 다 비어 있으면 오류
+    if (!content && !youtubeUrl && !imageFile) {
+      ctx.addIssue({
+        path: ['content'],
+        code: z.ZodIssueCode.custom,
+        message: '하나 이상의 항목을 입력해야 합니다.',
+      });
+    }
+
+    // 2. 둘 다 있으면 오류
+    if (youtubeUrl && imageFile) {
+      ctx.addIssue({
+        path: ['youtubeUrl'],
+        code: z.ZodIssueCode.custom,
+        message: '유튜브 링크와 이미지 중 하나만 입력할 수 있습니다.',
+      });
+      ctx.addIssue({
+        path: ['imageFile'],
+        code: z.ZodIssueCode.custom,
+        message: '유튜브 링크와 이미지 중 하나만 입력할 수 있습니다.',
+      });
+    }
+  });

--- a/kakaobase/src/stores/postStore.tsx
+++ b/kakaobase/src/stores/postStore.tsx
@@ -26,12 +26,24 @@ export interface PostState {
   setPostCardInfo: (post: Partial<PostState>) => void;
 }
 
-export const usePostStore = create<PostState>((set) => ({
+interface PostEditorState {
+  content?: string;
+  youtubeUrl?: string;
+  imageUrl?: string;
+  setEditorData: (data: {
+    content: string;
+    youtubeUrl: string;
+    imageUrl: string;
+  }) => void;
+  resetEditor: () => void;
+}
+
+export const usePostStore = create<PostState & PostEditorState>((set) => ({
   id: 1,
   userId: 1,
   nickname: '',
   userProfileUrl: '',
-  isMine: false,
+  isMine: true,
   type: 'post',
   content: '',
   ImageUrl: '',
@@ -50,4 +62,12 @@ export const usePostStore = create<PostState>((set) => ({
   onClickLike: () => {},
   onClickYoutubeSummary: () => {},
   setPostCardInfo: (post) => set((state) => ({ ...state, ...post })),
+  setEditorData: (data) => set((state) => ({ ...state, ...data })),
+  resetEditor: () =>
+    set((state) => ({
+      ...state,
+      content: '',
+      youtubeUrl: '',
+      imageUrl: '',
+    })),
 }));


### PR DESCRIPTION
## 변경사항

- 게시글 작성 페이지 구현
- 게시글 생성용 테스트 더미 데이터 작성
- 게시글 작성 api
- presigned-url, 이미지 등록 api 공부해야 함
- 게시글 작성 상태관리를 위한 store 수정

## 남은 일
- api 연결
- 유효성 검사 더 확실하게