### PR TITLE
[FIX] 회원가입 api 및 리팩토링 완료

### DIFF
--- a/kakaobase/.gitignore
+++ b/kakaobase/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/kakaobase/src/apis/api.tsx
+++ b/kakaobase/src/apis/api.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_API_URL,
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/kakaobase/src/apis/sendEmail.tsx
+++ b/kakaobase/src/apis/sendEmail.tsx
@@ -13,7 +13,7 @@ export default async function sendEmail({ email, purpose }: EmailVerification) {
     });
   } catch (e: unknown) {
     if (e instanceof Error) {
-      throw e.message;
+      throw e;
     }
   }
 }

--- a/kakaobase/src/apis/signup.tsx
+++ b/kakaobase/src/apis/signup.tsx
@@ -14,7 +14,7 @@ export default async function signup(payload: SignupRequest): Promise<void> {
     await api.post('/users', payload);
   } catch (e: unknown) {
     if (e instanceof Error) {
-      throw e.message;
+      throw e;
     }
   }
 }

--- a/kakaobase/src/apis/verifyCode.tsx
+++ b/kakaobase/src/apis/verifyCode.tsx
@@ -5,10 +5,13 @@ interface codeVerification {
   code: string;
 }
 
-export default async function verifyCode({ email, code }: codeVerification) {
+export default async function postCodeVerification({
+  email,
+  code,
+}: codeVerification) {
   try {
     await api.post('/users/email/verification', { email, code });
   } catch (e: unknown) {
-    if (e instanceof Error) throw e.message;
+    if (e instanceof Error) throw e;
   }
 }

--- a/kakaobase/src/components/user/EmailAuthStep.tsx
+++ b/kakaobase/src/components/user/EmailAuthStep.tsx
@@ -4,18 +4,18 @@ import UserInput from '../inputs/UserInput';
 
 export default function EmailAuthStep() {
   const {
-    codeInput,
-    setCodeInput,
-    emailInput,
-    setEmailInput,
+    code,
+    setCode,
+    email,
+    setEmail,
     error,
     isEmailValid,
     validateEmail,
     sendCode,
     verifyCode,
+    isCodeValid,
     codeError,
     timer,
-    isCodeValid,
     codeButtonLabel,
   } = useEmailAuth();
 
@@ -27,9 +27,9 @@ export default function EmailAuthStep() {
           placeholder="이메일을 입력하세요."
           type="text"
           errorMessage={timer.isRunning ? timer.formatted : error}
-          value={emailInput}
+          value={email}
           onChange={(e) => {
-            setEmailInput(e.target.value);
+            setEmail(e.target.value);
             validateEmail(e.target.value);
           }}
         />
@@ -45,12 +45,12 @@ export default function EmailAuthStep() {
           label="인증번호"
           placeholder="인증번호를 입력하세요.(6자리)"
           type="number"
-          value={codeInput}
+          value={code}
           errorMessage={codeError}
           maxLength={6}
           onChange={(e) => {
             const onlyNumbers = e.target.value.replace(/\D/g, '');
-            if (onlyNumbers.length <= 6) setCodeInput(onlyNumbers);
+            if (onlyNumbers.length <= 6) setCode(onlyNumbers);
           }}
         />
         <SubmitButtonSmall

--- a/kakaobase/src/components/user/EmailAuthStep.tsx
+++ b/kakaobase/src/components/user/EmailAuthStep.tsx
@@ -4,8 +4,8 @@ import UserInput from '../inputs/UserInput';
 
 export default function EmailAuthStep() {
   const {
-    code,
-    setCode,
+    codeInput,
+    setCodeInput,
     emailInput,
     setEmailInput,
     error,
@@ -45,12 +45,12 @@ export default function EmailAuthStep() {
           label="인증번호"
           placeholder="인증번호를 입력하세요.(6자리)"
           type="number"
-          value={code}
+          value={codeInput}
           errorMessage={codeError}
           maxLength={6}
           onChange={(e) => {
             const onlyNumbers = e.target.value.replace(/\D/g, '');
-            if (onlyNumbers.length <= 6) setCode(onlyNumbers);
+            if (onlyNumbers.length <= 6) setCodeInput(onlyNumbers);
           }}
         />
         <SubmitButtonSmall

--- a/kakaobase/src/components/user/PasswordStep.tsx
+++ b/kakaobase/src/components/user/PasswordStep.tsx
@@ -1,5 +1,5 @@
 import UserInput from '../inputs/UserInput';
-import { FieldErrors, UseFormRegister } from 'react-hook-form';
+import { FieldErrors, UseFormRegister, UseFormTrigger } from 'react-hook-form';
 import { z } from 'zod';
 import { passwordConfirmSchema } from '@/schemas/passwordConfirmSchema';
 
@@ -8,9 +8,14 @@ type PasswordStepFormData = z.infer<typeof passwordConfirmSchema>;
 interface PasswordStepProps {
   register: UseFormRegister<PasswordStepFormData>;
   errors: FieldErrors<PasswordStepFormData>;
+  trigger: UseFormTrigger<PasswordStepFormData>;
 }
 
-export default function PasswordStep({ register, errors }: PasswordStepProps) {
+export default function PasswordStep({
+  register,
+  errors,
+  trigger,
+}: PasswordStepProps) {
   return (
     <div className="flex flex-col gap-6">
       <UserInput
@@ -18,7 +23,11 @@ export default function PasswordStep({ register, errors }: PasswordStepProps) {
         placeholder="비밀번호를 입력하세요."
         type="password"
         errorMessage={errors.password?.message || ''}
-        {...register('password')}
+        {...register('password', {
+          onChange: () => {
+            trigger('confirm');
+          },
+        })}
       />
       <UserInput
         label="비밀번호 확인"

--- a/kakaobase/src/components/user/SignupStep1Form.tsx
+++ b/kakaobase/src/components/user/SignupStep1Form.tsx
@@ -1,48 +1,36 @@
 'use client';
 
-import { useAuthStore } from '@/stores/emailAuthStore';
+import { usePasswordStep } from '@/hooks/user/usePasswordStep';
 import SubmitButton from '../common/SubmitButton';
 import EmailAuthStep from './EmailAuthStep';
 import PasswordStep from './PasswordStep';
-import { usePasswordStep } from '@/hooks/user/usePasswordStep';
-import { useSignupStore } from '@/stores/signupStore';
-import { useRouter } from 'next/navigation';
+import { useSignupStep1 } from '@/hooks/user/useSignupStep1';
 
 export default function SignupStep1Form() {
   const {
     register,
-    handleSubmit,
     formState: { errors, isValid },
+    trigger,
+    getValues,
   } = usePasswordStep();
-
-  const isVerified = useAuthStore((state) => state.isVerified);
-  const email = useAuthStore((state) => state.email);
-  const setStep1 = useSignupStore((state) => state.setStep1);
-  const router = useRouter();
-
-  const onSubmit = (data: { password: string; confirm: string }) => {
-    setStep1({ email, password: data.password });
-    router.push('/signup/step2');
-  };
+  const { isVerified, onSubmitStep1 } = useSignupStep1();
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="min-h-[calc(100vh-10rem)] flex justify-center items-center animate-slide-in"
-    >
+    <div className="min-h-[calc(100vh-10rem)] flex justify-center items-center animate-slide-in">
       <div className="bg-containerColor m-8 px-8 py-12 rounded-xl flex flex-col items-center gap-6 w-full max-w-md">
         <div className="flex flex-col gap-6 w-full">
           <EmailAuthStep />
-          <PasswordStep register={register} errors={errors} />
+          <PasswordStep register={register} errors={errors} trigger={trigger} />
         </div>
         <div className="flex flex-col gap-[0.25rem] mt-4">
           <SubmitButton
             text="다음"
+            type="button"
             disabled={!isValid || !isVerified}
-            type="submit"
+            onClick={() => onSubmitStep1(getValues('password'))}
           />
         </div>
       </div>
-    </form>
+    </div>
   );
 }

--- a/kakaobase/src/components/user/SignupStep2Form.tsx
+++ b/kakaobase/src/components/user/SignupStep2Form.tsx
@@ -3,7 +3,7 @@
 import SubmitButton from '../common/SubmitButton';
 import CourseSelector from '../inputs/CourseSelector';
 import UserInput from '../inputs/UserInput';
-import { useSignupForm } from '@/hooks/user/useSingupForm';
+import { useSignupForm } from '@/hooks/user/useSingupStep2';
 
 export default function SignupStep2Form() {
   const {

--- a/kakaobase/src/hooks/auth/useEmailAuth.tsx
+++ b/kakaobase/src/hooks/auth/useEmailAuth.tsx
@@ -8,8 +8,6 @@ import postCodeVerification from '@/apis/verifyCode';
 
 export const useEmailAuth = () => {
   const pathName = usePathname();
-  const [codeInput, setCodeInput] = useState('');
-  const [emailInput, setEmailInput] = useState('');
   const [error, setError] = useState('');
   const [codeError, setCodeError] = useState('');
   const [isEmailValid, setEmailValid] = useState(false);
@@ -21,6 +19,9 @@ export const useEmailAuth = () => {
 
   const {
     verificationAttempts,
+    email,
+    code,
+    isVerified,
     setCode,
     setEmail,
     setVerified,
@@ -28,7 +29,7 @@ export const useEmailAuth = () => {
   } = useAuthStore();
 
   const timer = useAuthTimer(() => {
-    setCodeValid(false);
+    setVerified(false);
   });
 
   const validateEmail = (email: string) => {
@@ -39,12 +40,13 @@ export const useEmailAuth = () => {
   };
 
   const sendCode = async () => {
-    setEmail(emailInput);
+    setEmail(email);
     if (pathName.includes('signup')) {
       setPurpose('sign-up');
       try {
         timer.start();
-        await sendEmail({ email: emailInput, purpose });
+        await sendEmail({ email, purpose });
+        setEmailValid(true);
         setCodeValid(true);
       } catch (e: any) {
         console.log(e.response.data);
@@ -61,15 +63,15 @@ export const useEmailAuth = () => {
   };
 
   const verifyCode = async () => {
-    if (codeInput.length !== 6) return;
+    if (code.length !== 6) return;
 
     try {
-      await postCodeVerification({ email: emailInput, code: codeInput });
-      setCode(codeInput);
+      await postCodeVerification({ email, code });
+      setCode(code);
       setVerified(true);
       setCodeError('');
-      setCodeValid(false);
       setEmailValid(false);
+      setCodeValid(false);
       setCodeButtonLabel('완료');
       timer.stop();
     } catch (e: any) {
@@ -82,16 +84,16 @@ export const useEmailAuth = () => {
         return;
       } else if (e.response.data.error === 'email_code_fail_logout') {
         setCodeError(`*인증에 실패하였습니다. 잠시 후 시도해 주세요.`);
-        setCodeValid(false);
+        setVerified(false);
       }
     }
   };
 
   return {
-    codeInput,
-    setCodeInput,
-    emailInput,
-    setEmailInput,
+    email,
+    code,
+    setEmail,
+    setCode,
     error,
     isEmailValid,
     validateEmail,
@@ -99,7 +101,8 @@ export const useEmailAuth = () => {
     verifyCode,
     codeError,
     timer,
-    isCodeValid,
+    isVerified,
     codeButtonLabel,
+    isCodeValid,
   };
 };

--- a/kakaobase/src/hooks/auth/useEmailAuth.tsx
+++ b/kakaobase/src/hooks/auth/useEmailAuth.tsx
@@ -2,21 +2,28 @@ import { useState } from 'react';
 import { useAuthStore } from '@/stores/emailAuthStore';
 import { useAuthTimer } from './useAuthTimer';
 import { loginSchema } from '@/schemas/loginSchema';
+import sendEmail from '@/apis/sendEmail';
+import { usePathname } from 'next/navigation';
+import postCodeVerification from '@/apis/verifyCode';
 
 export const useEmailAuth = () => {
-  const [code, setCode] = useState('');
+  const pathName = usePathname();
+  const [codeInput, setCodeInput] = useState('');
   const [emailInput, setEmailInput] = useState('');
   const [error, setError] = useState('');
   const [codeError, setCodeError] = useState('');
   const [isEmailValid, setEmailValid] = useState(false);
   const [isCodeValid, setCodeValid] = useState(false);
   const [codeButtonLabel, setCodeButtonLabel] = useState('인증');
+  const [purpose, setPurpose] = useState<'sign-up' | 'password-reset'>(
+    'sign-up'
+  );
 
   const {
-    email,
+    verificationAttempts,
+    setCode,
     setEmail,
     setVerified,
-    verificationAttempts,
     incrementAttempt,
   } = useAuthStore();
 
@@ -31,40 +38,58 @@ export const useEmailAuth = () => {
     return result.success;
   };
 
-  const sendCode = () => {
+  const sendCode = async () => {
     setEmail(emailInput);
-    setCodeValid(true);
-    timer.start();
-    // await api.post('/auth/email-verification', { email: emailInput });
+    if (pathName.includes('signup')) {
+      setPurpose('sign-up');
+      try {
+        timer.start();
+        await sendEmail({ email: emailInput, purpose });
+        setCodeValid(true);
+      } catch (e: any) {
+        console.log(e.response.data);
+      }
+    }
+    // } else {
+    //   setPurpose('password-reset');
+    //   try {
+    //     await sendEmail({ email, purpose });
+    //   } catch (e) {
+    //     console.log(e);
+    //   }
+    // }
   };
 
-  const verifyCode = () => {
-    if (code.length !== 6) return;
+  const verifyCode = async () => {
+    if (codeInput.length !== 6) return;
 
-    if (code !== '123456') {
-      if (verificationAttempts >= 2) {
-        setCodeError(`*인증에 실패하였습니다. 잠시 후 시도해 주세요.`);
-        setCodeValid(false);
-      } else {
+    try {
+      await postCodeVerification({ email: emailInput, code: codeInput });
+      setCode(codeInput);
+      setVerified(true);
+      setCodeError('');
+      setCodeValid(false);
+      setEmailValid(false);
+      setCodeButtonLabel('완료');
+      timer.stop();
+    } catch (e: any) {
+      console.log(e.response);
+      if (e.response.data.error === 'email_code_invalid') {
         incrementAttempt();
         setCodeError(
           `*인증에 실패하였습니다. (시도 ${verificationAttempts + 1}/3)`
         );
+        return;
+      } else if (e.response.data.error === 'email_code_fail_logout') {
+        setCodeError(`*인증에 실패하였습니다. 잠시 후 시도해 주세요.`);
+        setCodeValid(false);
       }
-      return;
     }
-
-    setVerified(true);
-    setCodeError('');
-    setCodeValid(false);
-    setEmailValid(false);
-    setCodeButtonLabel('완료');
-    timer.stop();
   };
 
   return {
-    code,
-    setCode,
+    codeInput,
+    setCodeInput,
     emailInput,
     setEmailInput,
     error,

--- a/kakaobase/src/hooks/user/useSignupStep1.tsx
+++ b/kakaobase/src/hooks/user/useSignupStep1.tsx
@@ -1,0 +1,19 @@
+import { useAuthStore } from '@/stores/emailAuthStore';
+import { useSignupStore } from '@/stores/signupStore';
+import { useRouter } from 'next/navigation';
+
+export const useSignupStep1 = () => {
+  const { isVerified, email } = useAuthStore();
+  const { setStep1 } = useSignupStore();
+  const router = useRouter();
+
+  const onSubmitStep1 = (password: string) => {
+    setStep1({ email, password });
+    router.push('/signup/step2');
+  };
+
+  return {
+    isVerified,
+    onSubmitStep1,
+  };
+};

--- a/kakaobase/src/hooks/user/useSingupStep2.tsx
+++ b/kakaobase/src/hooks/user/useSingupStep2.tsx
@@ -1,3 +1,4 @@
+import signup from '@/apis/signup';
 import { signupStep2Schema } from '@/schemas/signupStep2Schema';
 import { useSignupStore } from '@/stores/signupStore';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -6,6 +7,15 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 export type SignupStep2Data = z.infer<typeof signupStep2Schema>;
+
+const courseMap: Record<string, string> = {
+  '클라우드 네이티브 제주 1기': 'JEJU_1',
+  '클라우드 네이티브 제주 2기': 'JEJU_2',
+  '카카오테크 부트캠프 1기': 'PANGYO_1',
+  '카카오테크 부트캠프 2기': 'PANGYO_2',
+  'KDT 관계자': 'KDT_STAFF',
+  '기타 사용자': 'OTHER',
+};
 
 export const useSignupForm = () => {
   const router = useRouter();
@@ -25,14 +35,32 @@ export const useSignupForm = () => {
     },
   });
 
-  const onSubmitStep2 = (data: SignupStep2Data) => {
+  const onSubmitStep2 = async (data: SignupStep2Data) => {
     setStep2Info({
       name: data.name,
       nickname: data.nickname,
       course: data.course,
       githubUrl: data.githubUrl,
     });
-    router.push('/login');
+    try {
+      if (!step1Info || !step2Info) return;
+      const request = {
+        email: step1Info.email,
+        password: step1Info.password,
+        name: step2Info.name,
+        nickname: step2Info.nickname,
+        class_name: courseMap[step2Info.course],
+        github_url: step2Info.githubUrl,
+      };
+      console.log(request);
+
+      const response = await signup(request);
+      console.log(response);
+
+      router.push('/login');
+    } catch (e: any) {
+      console.log(e.response);
+    }
   };
 
   return { ...methods, onSubmitStep2, step1Info, step2Info };

--- a/kakaobase/src/hooks/user/useSingupStep2.tsx
+++ b/kakaobase/src/hooks/user/useSingupStep2.tsx
@@ -52,7 +52,6 @@ export const useSignupForm = () => {
         class_name: courseMap[step2Info.course],
         github_url: step2Info.githubUrl,
       };
-      console.log(request);
 
       const response = await signup(request);
       console.log(response);

--- a/kakaobase/src/schemas/passwordConfirmSchema.tsx
+++ b/kakaobase/src/schemas/passwordConfirmSchema.tsx
@@ -16,7 +16,12 @@ export const passwordConfirmSchema = z
       .string()
       .min(1, { message: '*비밀번호를 한 번 더 입력해 주세요.' }),
   })
-  .refine((data) => data.password === data.confirm, {
-    message: '*비밀번호가 일치하지 않습니다.',
-    path: ['confirm'],
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirm) {
+      ctx.addIssue({
+        path: ['confirm'],
+        code: z.ZodIssueCode.custom,
+        message: '*비밀번호가 일치하지 않습니다.',
+      });
+    }
   });

--- a/kakaobase/src/stores/emailAuthStore.tsx
+++ b/kakaobase/src/stores/emailAuthStore.tsx
@@ -2,21 +2,33 @@ import { create } from 'zustand';
 
 interface EmailAuthState {
   email: string;
+  code: string;
   isVerified: boolean;
   verificationAttempts: number;
   setEmail: (email: string) => void;
+  setCode: (code: string) => void;
   setVerified: (status: boolean) => void;
   incrementAttempt: () => void;
   resetAttempts: () => void;
+  reset: () => void;
 }
 
 export const useAuthStore = create<EmailAuthState>((set) => ({
   email: '',
+  code: '',
   isVerified: false,
   verificationAttempts: 0,
   setEmail: (email) => set({ email }),
+  setCode: (code) => set({ code }),
   setVerified: (status) => set({ isVerified: status }),
   incrementAttempt: () =>
     set((state) => ({ verificationAttempts: state.verificationAttempts + 1 })),
   resetAttempts: () => set({ verificationAttempts: 0 }),
+  reset: () =>
+    set({
+      email: '',
+      code: '',
+      isVerified: false,
+      verificationAttempts: 0,
+    }),
 }));


### PR DESCRIPTION
## 이메일 인증 api
- api base url .env에 추가
- 인증 코드 인증 api 함수명 변경
- api : signup, sendEmail, verifyCode 에러 처리 수정
- 인증 코드가 일치하지 않을 경우 응답에 따라 예외 처리 수정 완료
- 이메일 전송 / 인증코드 api 2개 연결 완전 성공
- useEmailAuth.tsx에서 store에 저장되는 변수는 지역 변수에서 제거
    - 지역 / 전역 변수 중복 있었음
    - 이에 맞게 EmailAuthStep도 바뀜
- isVerified가 코드 입력 상태와 충돌하는 문제로 isCodeValid 추가

## 파일 이름 변경
- signup 훅 파일을 두 개로 분리하면서 파일 이름 변경
- useSignupForm -> useSignupStep2
- SignupStep2 컴포넌트 경로도 수정됨

## 비밀번호 유효성 검사
- 비밀번호 수정 시 비밀번호 확인 부분 에러 메시지가 업데이트 되지 않는 문제를 해결
- 컴포넌트에서도 trigger가 필요하여 PasswordStep에 파라미터로 보내도록 수정

## 리팩토링
- 회원가입 1단계 컴포넌트에 비즈니스 로직 들어간 부분 분리
- useSignupStep1.tsx 파일 추가

## 회원가입 api 연결 성공
- ui에 보이는 과정명 한국어를 백엔드에 요청 보내기 위해 영어로 변환해야 하는 문제 해결
- class_name 속성이 현재 백엔드에서 className으로 돼있음
    - 수정 요청 완료
    - 백엔드 릴리즈 업데이트 대기 중
    - 백엔드 클라우드 배포해야 함