### PR TITLE
[FIX] 게시글 도메인 1차 api

### DIFF
--- a/kakaobase/src/apis/commentList.tsx
+++ b/kakaobase/src/apis/commentList.tsx
@@ -1,0 +1,36 @@
+import { PostState } from '@/stores/postStore';
+import api from './api';
+import { getClientCookie } from '@/lib/getClientCookie';
+import { courseMap } from '@/lib/courseMap';
+import { PostType } from '@/lib/postType';
+import { mapToPostState } from '@/lib/mapPost';
+import { GetPostsParams } from './postList';
+
+export default async function getComments(
+  id: number,
+  { limit, cursor }: GetPostsParams
+): Promise<PostState[]> {
+  try {
+    // let course = getClientCookie('course');
+    // if (!course) course = '기타 사용자';
+    // const postType = courseMap[course] as PostType;
+    const postType = 'PANGYO_2';
+
+    const params: Record<string, any> = {};
+    if (limit !== undefined) params.limit = limit;
+    if (cursor !== undefined) params.cursor = cursor;
+
+    const response = await api.get(`/posts/${id}/comments`, {
+      params,
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
+
+    const rawPosts = response.data.data.comments;
+    return rawPosts.map(mapToPostState);
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
+    return [];
+  }
+}

--- a/kakaobase/src/apis/imageS3.tsx
+++ b/kakaobase/src/apis/imageS3.tsx
@@ -1,0 +1,19 @@
+import api from './api';
+
+export default async function postToS3(
+  file: File,
+  type: 'profile_image' | 'post_image'
+): Promise<string> {
+  const response = await api.get(
+    `/images/presigned-url?fileName=${file.name}&fileSize=${file.size}&mimeType=${file.type}&type=${type}`
+  );
+  const url = response.data.presigned_url;
+
+  await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': file.type },
+    body: file,
+  });
+
+  return response.data.image_url;
+}

--- a/kakaobase/src/apis/post.tsx
+++ b/kakaobase/src/apis/post.tsx
@@ -1,7 +1,8 @@
+import { PostType } from '@/lib/postType';
 import api from './api';
 
 interface postParams {
-  postType: 'all' | 'pangyo_1' | 'jeju_1' | 'pangyo_2' | 'jeju_2';
+  postType: PostType;
   id?: number;
 }
 
@@ -18,25 +19,24 @@ export async function deletePost({ postType, id }: postParams) {
 
 interface postBody {
   content?: string;
-  imageUrl?: string;
-  youtubeUrl?: string;
+  image_url?: string;
+  youtube_url?: string;
 }
 
 //게시글 생성
 export async function postPost(
   { postType }: postParams,
-  { content, imageUrl, youtubeUrl }: postBody
+  { content, image_url, youtube_url }: postBody
 ) {
   try {
     const response = await api.post(`/posts/${postType}`, {
       content,
-      imageUrl,
-      youtubeUrl,
+      image_url,
+      youtube_url,
     });
-    console.log(response.data);
     return response.data;
-  } catch (e) {
-    console.log(e);
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
   }
 }
 
@@ -44,7 +44,6 @@ export async function postPost(
 export async function getPost({ postType, id }: postParams) {
   try {
     const response = await api.get(`/posts/${postType}/${id}`);
-    console.log(response.data);
     return response.data;
   } catch (e) {
     console.log(e);

--- a/kakaobase/src/apis/postList.tsx
+++ b/kakaobase/src/apis/postList.tsx
@@ -1,21 +1,32 @@
 import { PostState } from '@/stores/postStore';
 import api from './api';
+import { getClientCookie } from '@/lib/getClientCookie';
+import { courseMap } from '@/lib/courseMap';
+import { PostType } from '@/lib/postType';
+import { mapToPostState } from '@/lib/mapPost';
 
-interface GetPostsParams {
-  limits?: number;
+export interface GetPostsParams {
+  limit?: number;
   cursor?: number;
+  id?: number;
 }
 
 export default async function getPosts({
-  limits,
+  limit,
   cursor,
 }: GetPostsParams): Promise<PostState[]> {
   try {
-    const postType = 'pangyo_2';
-    const response = await api.get(
-      `/posts/${postType}?limits=${limits}&cursor=${cursor}`
-    );
-    return response.data.data;
+    // let course = getClientCookie('course');
+    // if (!course) course = '기타 사용자';
+    // const postType = courseMap[course] as PostType;
+    const postType = 'PANGYO_2';
+
+    const params: Record<string, any> = {};
+    if (limit !== undefined) params.limit = limit;
+    if (cursor !== undefined) params.cursor = cursor;
+    const response = await api.get(`/posts/${postType}`, { params });
+    const rawPosts = response.data.data;
+    return rawPosts.map(mapToPostState);
   } catch (e: unknown) {
     if (e instanceof Error) throw e;
     return [];

--- a/kakaobase/src/apis/postList.tsx
+++ b/kakaobase/src/apis/postList.tsx
@@ -1,5 +1,5 @@
-import { dummyPosts } from '@/data/dummyPosts';
 import { PostState } from '@/stores/postStore';
+import api from './api';
 
 interface GetPostsParams {
   limits?: number;
@@ -11,26 +11,13 @@ export default async function getPosts({
   cursor,
 }: GetPostsParams): Promise<PostState[]> {
   try {
-    let filtered = [...dummyPosts].sort((a, b) => b.id - a.id); // 내림차순 정렬
-
-    if (cursor !== undefined) {
-      filtered = filtered.filter((post) => post.id < cursor); // 이전보다 작은 ID만 가져옴
-    }
-
-    if (limits !== undefined) {
-      filtered = filtered.slice(0, limits);
-    }
-
-    return await new Promise((resolve) => {
-      setTimeout(() => resolve(filtered), 300); // 300ms 지연 로딩 테스트하려고 일부러 함
-    });
-
-    // const response = await api.get(
-    //   `/posts?limits=${limits}&cursor=${cursor}`
-    // );
-    // return response.data;
-  } catch (e) {
-    console.log('getPosts() error:', e);
+    const postType = 'pangyo_2';
+    const response = await api.get(
+      `/posts/${postType}?limits=${limits}&cursor=${cursor}`
+    );
+    return response.data.data;
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
     return [];
   }
 }

--- a/kakaobase/src/app/post/[id]/comment/[id]/page.tsx
+++ b/kakaobase/src/app/post/[id]/comment/[id]/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+import Header from '@/components/common/header/Header';
+import MiddleBar from '@/components/common/MiddleBar';
+import CommentInput from '@/components/inputs/CommentInput';
+import PostCard from '@/components/post/PostCard';
+import PostList from '@/components/post/PostList';
+import usePostDetail from '@/hooks/post/usePostCardDetail';
+import { LoaderCircle } from 'lucide-react';
+
+export default function Page({ params }: { params: { id: number } }) {
+  const id = Number(params.id);
+  const { post, loading, error } = usePostDetail({ id });
+
+  if (loading)
+    return (
+      <div className="text-center text-xs font-bold mb-4 flex flex-col items-center my-10 gap-4">
+        <LoaderCircle
+          width={40}
+          height={40}
+          className="animate-spin text-textColor"
+        />
+        로딩 중...
+      </div>
+    );
+
+  if (!post || error) return <div>게시글을 찾을 수 없습니다.</div>;
+
+  return (
+    <div className="flex flex-col h-screen">
+      <Header label="답글 상세" />
+      <PostCard post={post} />
+      <MiddleBar />
+      <div className="overflow-y-auto flex flex-grow">
+        <PostList />
+      </div>
+      <CommentInput />
+    </div>
+  );
+}

--- a/kakaobase/src/components/post/PostList.tsx
+++ b/kakaobase/src/components/post/PostList.tsx
@@ -6,9 +6,7 @@ import PostCard from './PostCard';
 import { LoaderCircle } from 'lucide-react';
 
 export default function PostList() {
-  const { posts, loading, error, hasMore, fetchPosts } = usePosts({
-    limits: 6,
-  });
+  const { posts, loading, error, hasMore, fetchPosts } = usePosts(6);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<HTMLDivElement | null>(null);
 
@@ -33,7 +31,7 @@ export default function PostList() {
       },
       {
         root: container,
-        rootMargin: '0px 0px 100px 0px', //바닥에서 100px 위에 떨어진 스크롤 위치에서 추가 호출 발생
+        rootMargin: '0px 0px 10px 0px', //바닥에서 100px 위에 떨어진 스크롤 위치에서 추가 호출 발생
         threshold: 0,
       }
     );

--- a/kakaobase/src/hooks/post/usePostCardHook.tsx
+++ b/kakaobase/src/hooks/post/usePostCardHook.tsx
@@ -13,7 +13,7 @@ export default function usePosts(options?: UsePostsOptions) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [hasMore, setHasMore] = useState(true);
-  const [cursor, setCursor] = useState<number | null>(null);
+  const [cursor, setCursor] = useState(0);
 
   const fetchPosts = useCallback(async () => {
     //로딩 중이거나 더이상 데이터가 없으면 관두기
@@ -22,6 +22,7 @@ export default function usePosts(options?: UsePostsOptions) {
     try {
       setLoading(true);
       const data = await getPosts({ ...options, cursor: cursor ?? undefined });
+      console.log(data);
       //커서는 숫자이거나 undefined
 
       //데이터가 없으면 더이상 데이터가 없다고 표시하기

--- a/kakaobase/src/hooks/post/usePostCardHook.tsx
+++ b/kakaobase/src/hooks/post/usePostCardHook.tsx
@@ -1,28 +1,35 @@
 import { useCallback, useEffect, useState } from 'react';
 import getPosts from '@/apis/postList';
 import { PostState } from '@/stores/postStore';
+import { useParams, usePathname } from 'next/navigation';
+import getComments from '@/apis/commentList';
 
-interface UsePostsOptions {
-  limits?: number;
-  cursor?: number;
-  createdAt?: string;
-}
-
-export default function usePosts(options?: UsePostsOptions) {
+export default function usePosts(limit: number) {
   const [posts, setPosts] = useState<PostState[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [hasMore, setHasMore] = useState(true);
-  const [cursor, setCursor] = useState(0);
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
+  const path = usePathname();
+  const param = useParams();
 
   const fetchPosts = useCallback(async () => {
     //로딩 중이거나 더이상 데이터가 없으면 관두기
     if (loading || !hasMore) return;
+    const id = Number(param.id);
 
     try {
       setLoading(true);
-      const data = await getPosts({ ...options, cursor: cursor ?? undefined });
-      console.log(data);
+      let data = [];
+      if (path.includes('comment')) {
+        data = await getComments(id, { limit, cursor }); //댓글 상세 페이지
+      } else if (path.includes('post')) {
+        console.log('게시글 상세 페이지');
+        data = await getComments(id, { limit, cursor }); //게시글 상세 페이지
+        console.log(data);
+      } else {
+        data = await getPosts({ limit, cursor }); //메인 페이지
+      }
       //커서는 숫자이거나 undefined
 
       //데이터가 없으면 더이상 데이터가 없다고 표시하기
@@ -38,14 +45,14 @@ export default function usePosts(options?: UsePostsOptions) {
         });
 
         const lastId = data[data.length - 1].id; //데이터의 마지막 게시글의 id를 lastId로 정의
-        setCursor(lastId); // 커서 업데이트
+        setCursor(lastId - 1); // 커서 업데이트
       }
     } catch (err) {
       setError(err as Error);
     } finally {
       setLoading(false);
     }
-  }, [hasMore, loading, options]);
+  }, [hasMore, loading, limit]);
 
   return {
     posts,

--- a/kakaobase/src/lib/courseMap.tsx
+++ b/kakaobase/src/lib/courseMap.tsx
@@ -1,0 +1,7 @@
+export const courseMap: Record<string, string> = {
+  '클라우드 네이티브 제주 1기': 'JEJU_1',
+  '클라우드 네이티브 제주 2기': 'JEJU_2',
+  '카카오테크 부트캠프 1기': 'PANGYO_1',
+  '카카오테크 부트캠프 2기': 'PANGYO_2',
+  '기타 사용자': 'ALL',
+};

--- a/kakaobase/src/lib/getClientCookie.tsx
+++ b/kakaobase/src/lib/getClientCookie.tsx
@@ -1,0 +1,8 @@
+export function getClientCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()!.split(';').shift()!;
+  return null;
+}

--- a/kakaobase/src/lib/mapPost.tsx
+++ b/kakaobase/src/lib/mapPost.tsx
@@ -1,0 +1,47 @@
+import type { PostState } from '@/stores/postStore';
+
+interface PostResponseDto {
+  id: number;
+  content?: string;
+  image_url?: string;
+  youtube_url?: string;
+  comment_count: number;
+  like_count: number;
+  is_liked: boolean;
+  is_mine: boolean;
+  created_at: string;
+  user: {
+    id: number;
+    nickname: string;
+    image_url: string | null;
+    is_following: boolean;
+  };
+}
+
+export function mapToPostState(post: PostResponseDto): PostState {
+  return {
+    id: post.id,
+    userId: post.user.id,
+    nickname: post.user.nickname,
+    userProfileUrl: post.user.image_url ?? '',
+    isMine: post.is_mine,
+    type: 'post',
+    content: post.content ?? '',
+    ImageUrl: post.image_url ?? '',
+    youtubeUrl: post.youtube_url ?? '',
+    youtubeSummary: '',
+    commentCount: post.comment_count,
+    likeCount: post.like_count,
+    isFollowing: post.user.is_following,
+    isLiked: post.is_liked,
+    createdAt: post.created_at,
+    onClickFollow: () => {},
+    onClickReport: () => {},
+    onClickUser: () => {},
+    onClickPostCard: () => {},
+    onClickDelete: () => {},
+    onClickLike: () => {},
+    onClickYoutubeSummary: () => {},
+    setPostCardInfo: () => {},
+  };
+}

--- a/kakaobase/src/lib/postType.tsx
+++ b/kakaobase/src/lib/postType.tsx
@@ -1,0 +1,1 @@
+export type PostType = 'ALL' | 'PANGYO_1' | 'JEJU_1' | 'PANGYO_2' | 'JEJU_2';


### PR DESCRIPTION
## 게시글 목록 조회 api
- 게시글 목록 조회 api 요청 성공
- postType lib로 분리
- 응답 타입과 postState 타입이 달라 mapping하는 함수 작성
- postType ui, 요청 형식 다른 거 mapping
- cursor 기반 무한 스크롤 성공
- 백엔드 쿼리 파라미터 limits 아니고 limit이라고 함...

## 댓글 상세 페이지 생성
- 임시로 게시글 상세페이지와 동일하게 제작
- 나중에 layout.tsx 만들어서 객체지향적으로 바꿔야 함
- 게시글 상세에서 댓글 클릭시 넘어오는 페이지

## 댓글 목록 조회
- 댓글 목록 조회 api
- accessToken을 헤더에 보내야 해서 getClientCookie.tsx 파일 작성
- 쿠키 원하는 거 불러오는 동적 파일

## api에 맞게 변형
- 게시글 작성, 게시글 조회 api 파일에서 postType이 다른 데서도 많이 쓰여서 파일 분리하면서 지움
- 명세서에는 스네이크 형식인데 구현은 카멜 아니고 스네이크라고 함...

## 게시글 작성 api
- 임시로 작성한 상태
- 완성은 아님
- 백엔드 아직 인증 객체 문제 해결 안 됨
