### PR TITLE
[FIX] 게시글 도메인 api, 주석 처리

### DIFF
--- a/kakaobase/src/apis/comment.tsx
+++ b/kakaobase/src/apis/comment.tsx
@@ -1,4 +1,5 @@
 import api from './api';
+import { getClientCookie } from '@/lib/getClientCookie';
 
 //댓글 삭제
 export async function deleteComment({ id }: { id: number }) {
@@ -6,8 +7,8 @@ export async function deleteComment({ id }: { id: number }) {
     const response = await api.delete(`comments/${id}`);
     console.log(response.data);
     return response.data;
-  } catch (e) {
-    console.log(e);
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
   }
 }
 
@@ -20,33 +21,20 @@ export async function postComment({
   content: string;
 }) {
   try {
-    const response = await api.post(`/posts/${postId}/comments`, { content });
-    console.log(response.data);
-    return response.data;
-  } catch (e) {
-    console.log(e);
-  }
-}
-
-//게시글 목록 조회
-export async function getComment({
-  postId,
-  limits,
-  cursor,
-  createdAt,
-}: {
-  postId: number;
-  limits: number;
-  cursor: number;
-  createdAt: string;
-}) {
-  try {
-    const response = await api.get(
-      `/posts/${postId}/comments?limits=${limits}&cursor=${cursor}&created_at=${createdAt}`
+    const response = await api.post(
+      `/posts/${postId}/comments`,
+      {
+        content,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${getClientCookie('accessToken')}`,
+        },
+      }
     );
     console.log(response.data);
     return response.data;
-  } catch (e) {
-    console.log(e);
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
   }
 }

--- a/kakaobase/src/apis/commentList.tsx
+++ b/kakaobase/src/apis/commentList.tsx
@@ -1,8 +1,6 @@
 import { PostState } from '@/stores/postStore';
 import api from './api';
 import { getClientCookie } from '@/lib/getClientCookie';
-import { courseMap } from '@/lib/courseMap';
-import { PostType } from '@/lib/postType';
 import { mapToPostState } from '@/lib/mapPost';
 import { GetPostsParams } from './postList';
 
@@ -11,10 +9,8 @@ export default async function getComments(
   { limit, cursor }: GetPostsParams
 ): Promise<PostState[]> {
   try {
-    // let course = getClientCookie('course');
-    // if (!course) course = '기타 사용자';
-    // const postType = courseMap[course] as PostType;
-    const postType = 'PANGYO_2';
+    let postType = getClientCookie('course');
+    if (!postType) postType = '기타 사용자';
 
     const params: Record<string, any> = {};
     if (limit !== undefined) params.limit = limit;

--- a/kakaobase/src/apis/imageS3.tsx
+++ b/kakaobase/src/apis/imageS3.tsx
@@ -1,3 +1,4 @@
+import { getClientCookie } from '@/lib/getClientCookie';
 import api from './api';
 
 export default async function postToS3(
@@ -5,15 +6,25 @@ export default async function postToS3(
   type: 'profile_image' | 'post_image'
 ): Promise<string> {
   const response = await api.get(
-    `/images/presigned-url?fileName=${file.name}&fileSize=${file.size}&mimeType=${file.type}&type=${type}`
+    `/images/presigned-url?fileName=${file.name}&fileSize=${file.size}&mimeType=${file.type}&type=${type}`,
+    {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    }
   );
-  const url = response.data.presigned_url;
+
+  const url = response.data.data.presinged_url;
 
   await fetch(url, {
     method: 'PUT',
-    headers: { 'Content-Type': file.type },
+    headers: { 'Content-Type': 'application/octet-stream' },
     body: file,
+    mode: 'cors',
+  }).catch((error) => {
+    console.error('이미지 업로드 실패:', error);
+    throw error;
   });
 
-  return response.data.image_url;
+  return response.data.data.image_url;
 }

--- a/kakaobase/src/apis/post.tsx
+++ b/kakaobase/src/apis/post.tsx
@@ -1,5 +1,7 @@
 import { PostType } from '@/lib/postType';
 import api from './api';
+import { headers } from 'next/headers';
+import { getClientCookie } from '@/lib/getClientCookie';
 
 interface postParams {
   postType: PostType;
@@ -29,11 +31,19 @@ export async function postPost(
   { content, image_url, youtube_url }: postBody
 ) {
   try {
-    const response = await api.post(`/posts/${postType}`, {
-      content,
-      image_url,
-      youtube_url,
-    });
+    const response = await api.post(
+      `/posts/${postType}`,
+      {
+        content,
+        image_url,
+        youtube_url,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${getClientCookie('accessToken')}`,
+        },
+      }
+    );
     return response.data;
   } catch (e: unknown) {
     if (e instanceof Error) throw e;

--- a/kakaobase/src/apis/postList.tsx
+++ b/kakaobase/src/apis/postList.tsx
@@ -16,15 +16,18 @@ export default async function getPosts({
   cursor,
 }: GetPostsParams): Promise<PostState[]> {
   try {
-    // let course = getClientCookie('course');
-    // if (!course) course = '기타 사용자';
-    // const postType = courseMap[course] as PostType;
-    const postType = 'PANGYO_2';
+    let postType = getClientCookie('course');
+    if (!postType) postType = 'ALL';
 
     const params: Record<string, any> = {};
     if (limit !== undefined) params.limit = limit;
     if (cursor !== undefined) params.cursor = cursor;
-    const response = await api.get(`/posts/${postType}`, { params });
+    const response = await api.get(`/posts/${postType}`, {
+      params,
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
     const rawPosts = response.data.data;
     return rawPosts.map(mapToPostState);
   } catch (e: unknown) {

--- a/kakaobase/src/components/inputs/CommentInput.tsx
+++ b/kakaobase/src/components/inputs/CommentInput.tsx
@@ -1,17 +1,27 @@
+import { postComment } from '@/apis/comment';
 import { Send } from 'lucide-react';
+import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
 export default function CommentInput() {
   const [comment, setComment] = useState('');
+  const param = useParams();
+  const id = Number(param.id);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!comment.trim()) return;
-    //댓글 전송 api 호출 param : comment
-    setComment('');
+    try {
+      const response = await postComment({ postId: id, content: comment });
+      console.log(response);
+    } catch (e: any) {
+      console.log(e);
+    } finally {
+      setComment('');
+    }
   };
 
   return (

--- a/kakaobase/src/components/post/PostCard.tsx
+++ b/kakaobase/src/components/post/PostCard.tsx
@@ -5,6 +5,7 @@ import { useYoutubeHook } from '@/hooks/post/useYoutubeHook';
 import CountsInfo from './CountsInfo';
 import { UserProfile, UserInfo } from './UserInfo';
 import { useRouter } from 'next/navigation';
+import { extractYoutubeVideoId } from '@/lib/formatYoutube';
 
 export default function PostCard({ post }: { post: PostState }) {
   const router = useRouter();
@@ -43,7 +44,9 @@ export default function PostCard({ post }: { post: PostState }) {
               ) : null
             ) : (
               <iframe
-                src={`https://www.youtube-nocookie.com/embed/${post.youtubeUrl}`}
+                src={`https://www.youtube-nocookie.com/embed/${extractYoutubeVideoId(
+                  post.youtubeUrl
+                )}`}
                 title="유튜브 영상"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                 allowFullScreen

--- a/kakaobase/src/components/post/PostList.tsx
+++ b/kakaobase/src/components/post/PostList.tsx
@@ -4,8 +4,10 @@ import { useEffect, useRef } from 'react';
 import usePosts from '@/hooks/post/usePostCardHook';
 import PostCard from './PostCard';
 import { LoaderCircle } from 'lucide-react';
+import { usePathname } from 'next/navigation';
 
 export default function PostList() {
+  const path = usePathname();
   const { posts, loading, error, hasMore, fetchPosts } = usePosts(6);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<HTMLDivElement | null>(null);
@@ -58,7 +60,12 @@ export default function PostList() {
         <div ref={observerRef} className="h-px" /> // 바닥 1px로 sentinel 감지
       ) : (
         <div className="text-center text-xs font-bold mb-8">
-          게시글이 더이상 존재하지 않습니다.
+          {path.includes('comment')
+            ? '대댓글'
+            : path.includes('post')
+            ? '댓글'
+            : '게시글'}
+          이 더이상 존재하지 않습니다.
         </div>
       )}
 

--- a/kakaobase/src/components/post/UserInfo.tsx
+++ b/kakaobase/src/components/post/UserInfo.tsx
@@ -49,9 +49,9 @@ export function UserInfo({ post }: { post: PostState }) {
         >
           {post.nickname}
         </div>
-        {post.isMine ? null : (
+        {/* {post.isMine ? null : (
           <FollowButtonSmall isFollowing={post.isFollowing} />
-        )}
+        )} */}
       </div>
       <div className="flex gap-2 align-center justify-center flex-shrink-0">
         <div className="flex self-center text-xs">
@@ -64,14 +64,14 @@ export function UserInfo({ post }: { post: PostState }) {
             className="self-center cursor-pointer"
             onClick={openModal}
           />
-        ) : (
-          <ShieldAlert
-            width={16}
-            height={16}
-            className="self-center cursor-pointer"
-            onClick={() => router.push('/report')}
-          />
-        )}
+        ) : // <ShieldAlert
+        //   width={16}
+        //   height={16}
+        //   className="self-center cursor-pointer"
+        //   onClick={() => router.push('/report')}
+        // />
+        //mvp 때 신고 페이지를 구현하지 않아 주석 처리
+        null}
       </div>
       {isOpened ? (
         <DeleteModal closeFunction={closeModal} okFunction={deletePost} />

--- a/kakaobase/src/hooks/post/usePostCardHook.tsx
+++ b/kakaobase/src/hooks/post/usePostCardHook.tsx
@@ -24,13 +24,10 @@ export default function usePosts(limit: number) {
       if (path.includes('comment')) {
         data = await getComments(id, { limit, cursor }); //댓글 상세 페이지
       } else if (path.includes('post')) {
-        console.log('게시글 상세 페이지');
         data = await getComments(id, { limit, cursor }); //게시글 상세 페이지
-        console.log(data);
       } else {
         data = await getPosts({ limit, cursor }); //메인 페이지
       }
-      //커서는 숫자이거나 undefined
 
       //데이터가 없으면 더이상 데이터가 없다고 표시하기
       if (data.length === 0) {

--- a/kakaobase/src/hooks/post/usePostEditorForm.tsx
+++ b/kakaobase/src/hooks/post/usePostEditorForm.tsx
@@ -1,13 +1,11 @@
 import postToS3 from '@/apis/imageS3';
 import { postPost } from '@/apis/post';
-import { courseMap } from '@/lib/courseMap';
 import { getClientCookie } from '@/lib/getClientCookie';
 import { PostType } from '@/lib/postType';
 import { postSchema } from '@/schemas/postSchema';
 import { usePostStore } from '@/stores/postStore';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { cookies } from 'next/headers';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -32,9 +30,8 @@ export const usePostEditorForm = () => {
   });
 
   const onSubmit = async (data: NewPostData) => {
-    const course = getClientCookie('course');
-    if (!course) return;
-    const postType = courseMap[course] as PostType;
+    let postType = getClientCookie('course') as PostType;
+    if (!postType) postType = 'ALL';
 
     try {
       let imageUrl = '';
@@ -43,7 +40,7 @@ export const usePostEditorForm = () => {
       }
 
       const response = await postPost(
-        { postType: postType },
+        { postType },
         {
           content: data.content,
           image_url: imageUrl,
@@ -51,9 +48,9 @@ export const usePostEditorForm = () => {
         }
       );
 
-      router.push(`/post/${response.data.data.id}`);
+      router.push(`/post/${response.data.id}`);
     } catch (e: any) {
-      console.log(e);
+      console.log('게시글 업로드 실패:', e);
     }
   };
 

--- a/kakaobase/src/lib/formatYoutube.tsx
+++ b/kakaobase/src/lib/formatYoutube.tsx
@@ -1,0 +1,8 @@
+export function extractYoutubeVideoId(url: string): string | null {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.searchParams.get('v');
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
## 게시글 목록 조회 api 수정
- accessToken 헤더에 추가
- 쿠키에서 postType 꺼내서 쓰기

## 게시글 작성 api 수정
- 이미지 등록 성공
- 유튜브 등록 성공
- content 등록 성공
- 백엔드에서 오는 유튜브 응답과 프론트가 달라 처리하는 함수 추가 ) formatYoutube.tsx
- 반영된 파일 : PostCard.tsx
- formatYoutube.tsx 구현한 걸 사용하여 백엔드에서 전송하는 youtube_url을 youtube_id로 변환하여 ui 제공

## 답글 생성 api
- **comment.tsx**
- 답글 생성 api에서 createdAt 제거
- 헤더에 액세스 토큰 추가
- 예러 처리 방식 수정
- **CommentInput.tsx**
- 지금 ui랑 비즈니스 로직 분리 안 돼있는 거 추후에 반영하기
- 댓글 작성 api와 연결하는 로직 추가

## 답글 목록 조회 api 수정
- commentList.tsx
- postType은 쿠키에서 꺼내 쓰도록 수정

## 게시글 작성 상태 관리 수정
- usePostEditorForm.tsx
- 게시글 작성에서 이미지 등록 안 되던 문제 함께 해결
- 응답 데이터에서 data하나 더 하위로 들어갔어야 함
- postType 쿠키에서 꺼내서 사용하는 방식 적절히 수정

## 주석 추가 및 제거
- console에 출력하는 거 제거
- 불필요한 주석 제거
- **usePostCardHook.tsx**
- 신고 페이지로 이동하면 안 되기 때문에 신고 버튼 제거
- 팔로우/팔로잉 기능 백엔드 v1에서 하지 않기 때문에 제거
- 해당 부분들 주석 처리함
- **UserInfo.tsx**

## 사용자에게 보이는 안내문 수정
 - 게시글 목록, 게시글 상세, 댓글 상세 페이지에 따라 post 목록이 없을 경우 다르게 보여아 함
-> 삼항 연산자 사용하여 반영
- **PostList.tsx**