### PR TITLE
[ FIX/FEAT ] 게시글 도메인 수정 및 게시글 삭제 api

### DIFF
--- a/kakaobase/src/apis/post.tsx
+++ b/kakaobase/src/apis/post.tsx
@@ -11,7 +11,11 @@ interface postParams {
 //게시글 삭제
 export async function deletePost({ postType, id }: postParams) {
   try {
-    const response = await api.delete(`posts/${postType}/${id}`);
+    const response = await api.delete(`posts/${postType}/${id}`, {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
     console.log(response.data);
     return response.data;
   } catch (e) {
@@ -53,8 +57,12 @@ export async function postPost(
 //게시글 상세 조회
 export async function getPost({ postType, id }: postParams) {
   try {
-    const response = await api.get(`/posts/${postType}/${id}`);
-    return response.data;
+    const response = await api.get(`/posts/${postType}/${id}`, {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
+    return response.data.data;
   } catch (e) {
     console.log(e);
   }

--- a/kakaobase/src/components/common/MiddleBar.tsx
+++ b/kakaobase/src/components/common/MiddleBar.tsx
@@ -1,11 +1,13 @@
-import { Undo2 } from 'lucide-react';
+import { usePathname } from 'next/navigation';
 
 export default function MiddleBar() {
+  const path = usePathname();
   return (
     <div className="py-4 px-6 border-y-[1px] border-textOpacity50 flex items-center">
       <div className="flex gap-4 text-textColor">
-        <Undo2 />
-        <div className="font-bold text-lg">답글</div>
+        <div className="font-bold text-lg">
+          {path.includes('comment') ? '대댓글' : '답글'}
+        </div>
       </div>
     </div>
   );

--- a/kakaobase/src/components/inputs/CommentInput.tsx
+++ b/kakaobase/src/components/inputs/CommentInput.tsx
@@ -21,6 +21,7 @@ export default function CommentInput() {
       console.log(e);
     } finally {
       setComment('');
+      window.location.reload(); // 나중에 바꿔야 함
     }
   };
 

--- a/kakaobase/src/components/post/DeleteModal.tsx
+++ b/kakaobase/src/components/post/DeleteModal.tsx
@@ -6,7 +6,7 @@ export default function DeleteModal({
   okFunction: () => void;
 }) {
   return (
-    <div className="flex fixed items-center justify-center z-[100] w-full h-full bg-transparent right-[-14rem] top-0">
+    <div className="flex fixed items-center justify-center z-[100] w-full h-full bg-transparent lg:right-[-14rem] right-0 top-0">
       <div className="absolute bg-bgColor opacity-50 max-w-[420px] w-full h-full"></div>
       <div className="relative px-12 py-6 z-200 bg-innerContainerColor flex items-center flex-col gap-6 rounded-xl">
         <div className="text-lg text-textColor">삭제하시겠습니까?</div>

--- a/kakaobase/src/components/post/PostCard.tsx
+++ b/kakaobase/src/components/post/PostCard.tsx
@@ -19,50 +19,49 @@ export default function PostCard({ post }: { post: PostState }) {
         <UserProfile post={post} />
         <div className="w-full flex flex-col gap-2 text-textColor">
           <UserInfo post={post} />
-
-          {post.content ? (
-            <div
-              className="w-full text-sm overflow-hidden cursor-pointer line-clamp-2 text-ellipsis"
-              onClick={navDetail}
-            >
-              {post.content}
-            </div>
-          ) : null}
-
-          <div className="flex justify-center content-center w-full overflow-hidden rounded-lg">
-            {!post.youtubeUrl ? (
-              post.ImageUrl ? (
-                <Image
-                  src={post.ImageUrl}
-                  alt="이미지"
-                  className="w-full h-auto object-cover rounded-lg"
-                  width={0}
-                  height={0}
-                  priority
-                  sizes="100vw"
-                />
-              ) : null
-            ) : (
-              <iframe
-                src={`https://www.youtube-nocookie.com/embed/${extractYoutubeVideoId(
-                  post.youtubeUrl
-                )}`}
-                title="유튜브 영상"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowFullScreen
-                loading="lazy"
-                className="w-full h-full aspect-video"
-              ></iframe>
-            )}
-          </div>
-          {post.youtubeUrl ? (
-            <div className="text-xs text-textColor">
-              <div className="cursor-pointer" onClick={showSummary}>
-                {summaryButton}
+          <div onClick={navDetail}>
+            {post.content ? (
+              <div className="w-full text-sm overflow-hidden cursor-pointer line-clamp-2 text-ellipsis">
+                {post.content}
               </div>
-              {isOpen ? <div>{post.youtubeSummary}</div> : null}
+            ) : null}
+
+            <div className="flex justify-center content-center w-full overflow-hidden rounded-lg">
+              {!post.youtubeUrl ? (
+                post.ImageUrl ? (
+                  <Image
+                    src={post.ImageUrl}
+                    alt="이미지"
+                    className="w-full h-auto object-cover rounded-lg"
+                    width={0}
+                    height={0}
+                    priority
+                    sizes="100vw"
+                    unoptimized
+                  />
+                ) : null
+              ) : (
+                <iframe
+                  src={`https://www.youtube-nocookie.com/embed/${extractYoutubeVideoId(
+                    post.youtubeUrl
+                  )}`}
+                  title="유튜브 영상"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
+                  loading="lazy"
+                  className="w-full h-full aspect-video"
+                ></iframe>
+              )}
             </div>
-          ) : null}
+            {/* {post.youtubeUrl ? (
+              <div className="text-xs text-textColor">
+                <div className="cursor-pointer" onClick={showSummary}>
+                  {summaryButton}
+                </div>
+                {isOpen ? <div>{post.youtubeSummary}</div> : null}
+              </div>
+            ) : null} */}
+          </div>
           <CountsInfo post={post} />
         </div>
       </div>

--- a/kakaobase/src/components/post/PostEditor.tsx
+++ b/kakaobase/src/components/post/PostEditor.tsx
@@ -4,7 +4,6 @@ import { Image, Youtube } from 'lucide-react';
 import SubmitButton from '../common/SubmitButton';
 import { NewPostData, usePostEditorForm } from '@/hooks/post/usePostEditorForm';
 import { useEffect, useState } from 'react';
-import SubmitButtonSmall from '../common/SubmitButtonSmall';
 import {
   FieldErrors,
   UseFormRegister,
@@ -90,23 +89,28 @@ function ImageInput({
   }, [imageFile]);
   return (
     <div className="w-full">
-      <label className="flex gap-2 items-center cursor-pointer">
-        <Image />
+      <label
+        htmlFor="image-upload"
+        className="flex gap-2 items-center cursor-pointer"
+      >
+        <Image className="w-4 h-4" />
         <div className="text-xs px-4 py-1 bg-myLightBlue w-40 text-center rounded-full text-textOnLight">
           이미지 업로드
         </div>
-        <input
-          type="file"
-          accept="image/png, image/jpeg, image/jpg, image/webp"
-          className="hidden"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              setValue('imageFile', file, { shouldValidate: true });
-            }
-          }}
-        />
       </label>
+
+      <input
+        id="image-upload"
+        type="file"
+        accept="image/png, image/jpeg, image/jpg, image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) {
+            setValue('imageFile', file, { shouldValidate: true });
+          }
+        }}
+      />
 
       {/* 이미지 미리보기 */}
       {previewUrl && (

--- a/kakaobase/src/components/post/PostList.tsx
+++ b/kakaobase/src/components/post/PostList.tsx
@@ -60,12 +60,13 @@ export default function PostList() {
         <div ref={observerRef} className="h-px" /> // 바닥 1px로 sentinel 감지
       ) : (
         <div className="text-center text-xs font-bold mb-8">
+          마지막&nbsp;
           {path.includes('comment')
             ? '대댓글'
             : path.includes('post')
             ? '댓글'
             : '게시글'}
-          이 더이상 존재하지 않습니다.
+          입니다.
         </div>
       )}
 

--- a/kakaobase/src/components/post/UserInfo.tsx
+++ b/kakaobase/src/components/post/UserInfo.tsx
@@ -15,7 +15,7 @@ export function UserProfile({ post }: { post: PostState }) {
   return (
     <div
       className="flex w-8 h-7 rounded-lg bg-innerContainerColor justify-center items-center cursor-pointer"
-      onClick={navProfile}
+      //onClick={navProfile}
     >
       {post.userProfileUrl ? (
         <Image
@@ -34,18 +34,21 @@ export function UserProfile({ post }: { post: PostState }) {
 }
 
 export function UserInfo({ post }: { post: PostState }) {
+  const id = Number(post.id);
   const router = useRouter();
   function navProfile() {
     router.push(`/profile/${post.userId}`);
   }
-  const { isOpened, openModal, closeModal, deletePost } = useDeleteHook();
+  const { isOpened, openModal, closeModal, deletePostExecute } = useDeleteHook({
+    id,
+  });
 
   return (
     <div className="flex justify-between gap-2">
       <div className="flex gap-2 items-center min-w-0">
         <div
           className="cursor-pointer font-bold text-sm overflow-hidden text-ellipsis whitespace-nowrap"
-          onClick={navProfile}
+          // onClick={navProfile}
         >
           {post.nickname}
         </div>
@@ -74,7 +77,10 @@ export function UserInfo({ post }: { post: PostState }) {
         null}
       </div>
       {isOpened ? (
-        <DeleteModal closeFunction={closeModal} okFunction={deletePost} />
+        <DeleteModal
+          closeFunction={closeModal}
+          okFunction={deletePostExecute}
+        />
       ) : null}
     </div>
   );

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -1,13 +1,25 @@
-import { useRouter } from 'next/navigation';
+import { deletePost } from '@/apis/post';
+import { getClientCookie } from '@/lib/getClientCookie';
+import { PostType } from '@/lib/postType';
+import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-export function useDeleteHook() {
+export function useDeleteHook({ id }: { id: number }) {
+  let postType = getClientCookie('course') as PostType;
+  if (!postType) postType = 'ALL';
+
   const router = useRouter();
+  const path = usePathname();
   const [isOpened, setOpen] = useState(false);
-  function deletePost() {
-    //삭제 api 호출
-    setOpen(false);
-    router.push('/');
+  async function deletePostExecute() {
+    try {
+      await deletePost({ postType, id });
+      setOpen(false);
+      if (path.includes('post')) router.push('/');
+      else window.location.reload(); //얘도 나중에 바꿔야 함
+    } catch (e: any) {
+      console.log(e);
+    }
   }
   function closeModal() {
     setOpen(false);
@@ -15,5 +27,5 @@ export function useDeleteHook() {
   function openModal() {
     setOpen(true);
   }
-  return { isOpened, deletePost, closeModal, openModal };
+  return { isOpened, deletePostExecute, closeModal, openModal };
 }

--- a/kakaobase/src/hooks/post/usePostCardDetail.tsx
+++ b/kakaobase/src/hooks/post/usePostCardDetail.tsx
@@ -10,7 +10,7 @@ export default function usePostDetail({ id }: { id: number }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetchPosts = async () => {
+  const fetchPost = async () => {
     let postType = getClientCookie('course') as PostType;
     if (!postType) postType = 'ALL';
 
@@ -26,7 +26,7 @@ export default function usePostDetail({ id }: { id: number }) {
   };
 
   useEffect(() => {
-    fetchPosts();
+    fetchPost();
   }, [id]);
 
   return {

--- a/kakaobase/src/hooks/post/usePostCardHook.tsx
+++ b/kakaobase/src/hooks/post/usePostCardHook.tsx
@@ -42,7 +42,7 @@ export default function usePosts(limit: number) {
         });
 
         const lastId = data[data.length - 1].id; //데이터의 마지막 게시글의 id를 lastId로 정의
-        setCursor(lastId - 1); // 커서 업데이트
+        setCursor(lastId); // 커서 업데이트
       }
     } catch (err) {
       setError(err as Error);

--- a/kakaobase/src/hooks/post/usePostEditorForm.tsx
+++ b/kakaobase/src/hooks/post/usePostEditorForm.tsx
@@ -16,7 +16,6 @@ export const usePostEditorForm = () => {
   const content = usePostStore((state) => state.content);
   const youtubeUrl = usePostStore((state) => state.youtubeUrl);
   const imageUrl = usePostStore((state) => state.imageUrl);
-  const setEditorData = usePostStore((state) => state.setEditorData);
 
   const methods = useForm<NewPostData>({
     resolver: zodResolver(postSchema),


### PR DESCRIPTION
## 📌추후 수정해야 할 부분
### 게시글 삭제 / 댓글 등록
- 즉시 업데이트 안 돼서 `window.location.reload()` 우선 임시방편으로 넣어둠

## 변경 사항
### 깨지거나 거슬리는 디자인 수정
- middlebar에 뒤로가기 삭제
- middlebar 댓글/대댓글 조건 처리
- 삭제 모달 화면 반응형으로 수정
- 게시글/댓글/대댓글이 더이상 없을 때 메시지 수정

### 코드 정리
- 안 쓰는 코드 삭제
- 복수/단수 안 맞는 거 수정 : usePostCardDetail.tsx
- 게시글 작성에서 이미지 업로드할 때 레이블 할당 코드 리팩토링 (사실 상관 없음)

### ux 향상 및 버그 수정
- usePostCardHook.tsx
    - cursor 하나 밀려서 반환받는 문제
    - cursor lastId로 세팅하는 걸로 수정
- PostCard.tsx
    - navigate 범위 수정
    - 요약 보기 버튼 우선 mvp 때 없어서 제거

## api 구현
### 게시글 삭제 api 연결
- header에 액세스 토큰 추가
- api, hook 함수명  겹처서 수정
- UserInfo에서 마이페이지 mvp 때 없어서 라우팅 주석 처리
- hook에 실질적으로 삭제 로직 연결