### PR TITLE
[FEAT] api 완성

### DIFF
--- a/kakaobase/src/apis/comment.tsx
+++ b/kakaobase/src/apis/comment.tsx
@@ -4,8 +4,11 @@ import { getClientCookie } from '@/lib/getClientCookie';
 //댓글 삭제
 export async function deleteComment({ id }: { id: number }) {
   try {
-    const response = await api.delete(`comments/${id}`);
-    console.log(response.data);
+    const response = await api.delete(`comments/${id}`, {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
     return response.data;
   } catch (e: unknown) {
     if (e instanceof Error) throw e;
@@ -32,7 +35,6 @@ export async function postComment({
         },
       }
     );
-    console.log(response.data);
     return response.data;
   } catch (e: unknown) {
     if (e instanceof Error) throw e;

--- a/kakaobase/src/apis/like.tsx
+++ b/kakaobase/src/apis/like.tsx
@@ -1,3 +1,4 @@
+import { getClientCookie } from '@/lib/getClientCookie';
 import api from './api';
 
 interface idParam {
@@ -7,7 +8,15 @@ interface idParam {
 //게시글 좋아요 등록
 export async function likePost({ id }: idParam) {
   try {
-    const response = await api.post(`/posts/${id}/likes`);
+    const response = await api.post(
+      `/posts/${id}/likes`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${getClientCookie('accessToken')}`,
+        },
+      }
+    );
     console.log(response.data);
     return response.data;
   } catch (e) {
@@ -18,7 +27,11 @@ export async function likePost({ id }: idParam) {
 //게시글 좋아요 취소
 export async function deletePostLike({ id }: idParam) {
   try {
-    const response = await api.delete(`/posts/${id}/likes`);
+    const response = await api.delete(`/posts/${id}/likes`, {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
     console.log(response.data);
     return response.data;
   } catch (e) {
@@ -29,7 +42,15 @@ export async function deletePostLike({ id }: idParam) {
 //댓글 좋아요 등록
 export async function likeComment({ id }: idParam) {
   try {
-    const response = await api.post(`/comments/${id}/likes`);
+    const response = await api.post(
+      `/comments/${id}/likes`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${getClientCookie('accessToken')}`,
+        },
+      }
+    );
     console.log(response.data);
     return response.data;
   } catch (e) {
@@ -38,9 +59,13 @@ export async function likeComment({ id }: idParam) {
 }
 
 //댓글 좋아요 취소
-export async function deleteCommenttLike({ id }: idParam) {
+export async function deleteCommentLike({ id }: idParam) {
   try {
-    const response = await api.delete(`/comments/${id}/likes`);
+    const response = await api.delete(`/comments/${id}/likes`, {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
     console.log(response.data);
     return response.data;
   } catch (e) {

--- a/kakaobase/src/apis/post.tsx
+++ b/kakaobase/src/apis/post.tsx
@@ -16,7 +16,6 @@ export async function deletePost({ postType, id }: postParams) {
         Authorization: `Bearer ${getClientCookie('accessToken')}`,
       },
     });
-    console.log(response.data);
     return response.data;
   } catch (e) {
     console.log(e);

--- a/kakaobase/src/components/post/CountsInfo.tsx
+++ b/kakaobase/src/components/post/CountsInfo.tsx
@@ -52,7 +52,9 @@ export default function CountsInfo({ post }: { post: PostState }) {
 
   const { isLiked, likeCount, toggleLike } = useLikeToggle(
     post.isLiked,
-    post.likeCount
+    post.likeCount,
+    post.id,
+    post.type
   );
 
   function navDetail() {

--- a/kakaobase/src/components/post/UserInfo.tsx
+++ b/kakaobase/src/components/post/UserInfo.tsx
@@ -35,12 +35,14 @@ export function UserProfile({ post }: { post: PostState }) {
 
 export function UserInfo({ post }: { post: PostState }) {
   const id = Number(post.id);
+  const type = post.type;
   const router = useRouter();
   function navProfile() {
     router.push(`/profile/${post.userId}`);
   }
   const { isOpened, openModal, closeModal, deletePostExecute } = useDeleteHook({
     id,
+    type,
   });
 
   return (

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -1,10 +1,11 @@
+import { deleteComment } from '@/apis/comment';
 import { deletePost } from '@/apis/post';
 import { getClientCookie } from '@/lib/getClientCookie';
 import { PostType } from '@/lib/postType';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-export function useDeleteHook({ id }: { id: number }) {
+export function useDeleteHook({ id, type }: { id: number; type: string }) {
   let postType = getClientCookie('course') as PostType;
   if (!postType) postType = 'ALL';
 
@@ -13,10 +14,16 @@ export function useDeleteHook({ id }: { id: number }) {
   const [isOpened, setOpen] = useState(false);
   async function deletePostExecute() {
     try {
-      await deletePost({ postType, id });
+      if (type === 'post') await deletePost({ postType, id });
+      else if (type === 'comment') await deleteComment({ id });
+      // else await deleteRecomment({id}); // 대댓글 삭제
       setOpen(false);
-      if (path.includes('post')) router.push('/');
-      else window.location.reload(); //얘도 나중에 바꿔야 함
+      if (path.includes('post') && type === 'post')
+        router.push('/'); //게시글 상세에서 게시글 지우기
+      else if (path.includes('comment') && type === 'comment')
+        router.back(); //댓글 상세에서 댓글 지우기
+      else window.location.reload(); //댓글 상세에서 대댓글 지우기
+      //얘도 나중에 바꿔야 함
     } catch (e: any) {
       console.log(e);
     }

--- a/kakaobase/src/hooks/user/useLikeHook.tsx
+++ b/kakaobase/src/hooks/user/useLikeHook.tsx
@@ -1,19 +1,42 @@
+import {
+  deleteCommentLike,
+  deletePostLike,
+  likeComment,
+  likePost,
+} from '@/apis/like';
 import { useState } from 'react';
 
-export function useLikeToggle(initial: boolean, likeCnt: number) {
+export function useLikeToggle(
+  initial: boolean,
+  likeCnt: number,
+  id: number,
+  type: string
+) {
   const [isLiked, setLiked] = useState(initial);
   const [likeCount, setLikeCount] = useState(likeCnt);
 
   const toggleLike = async () => {
     try {
-      if (isLiked) {
-        // 좋아요 취소 api
-        setLikeCount((prev) => prev - 1);
-      } else {
-        // 좋아요 등록 api
-        setLikeCount((prev) => prev + 1);
+      let reponse = {};
+      if (type === 'post') {
+        if (isLiked) {
+          reponse = await deletePostLike({ id });
+          setLikeCount((prev) => prev - 1);
+        } else {
+          reponse = await likePost({ id });
+          setLikeCount((prev) => prev + 1);
+        }
+      } else if (type === 'comment') {
+        if (isLiked) {
+          const reponse = await deleteCommentLike({ id });
+          setLikeCount((prev) => prev - 1);
+        } else {
+          const reponse = await likeComment({ id });
+          setLikeCount((prev) => prev + 1);
+        }
       }
       setLiked(!isLiked);
+      console.log(reponse);
     } catch (e) {
       console.error('팔로우 토글 실패', e);
     }


### PR DESCRIPTION
## 댓글 삭제
- 현재 댓글 삭제 구현 불가
- 댓글의 type이 post로 돼있음
- post.tsx ) console 출력 문구 제거

## 좋아요 등록 api 연결 성공
- 게시글 좋아요 등록/취소 성공
- 답글 삭제와 마찬가지로 답글, 대댓글 좋아요 등록 취소가 불가능