### PR TITLE
[FEAT] 대댓글 구현

### DIFF
--- a/kakaobase/src/apis/comment.tsx
+++ b/kakaobase/src/apis/comment.tsx
@@ -32,15 +32,18 @@ export async function getComment({ id }: { id: number }) {
 export async function postComment({
   postId,
   content,
+  parent_id,
 }: {
   postId: number;
   content: string;
+  parent_id?: number;
 }) {
   try {
     const response = await api.post(
       `/posts/${postId}/comments`,
       {
         content,
+        parent_id,
       },
       {
         headers: {

--- a/kakaobase/src/apis/recomment.tsx
+++ b/kakaobase/src/apis/recomment.tsx
@@ -1,0 +1,69 @@
+import { getAccessToken } from '@/lib/getClientCookie';
+import api from './api';
+import { GetPostsParams } from './postList';
+import { Post } from '@/stores/postType';
+import { mapToPostEntity } from '@/lib/mapPost';
+
+//대댓글 목록 조회
+export async function getRecomments(
+  commentId: number,
+  { limit, cursor }: GetPostsParams
+): Promise<Post[]> {
+  try {
+    const params: Record<string, any> = {};
+    if (limit !== undefined) params.limit = limit;
+    if (cursor !== undefined) params.cursor = cursor;
+    const response = await api.get(`/comments/${commentId}/recomments`, {
+      params,
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+    });
+    return response.data.data.recomments.map((p: any) =>
+      mapToPostEntity(p, 'recomment')
+    );
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
+    return [];
+  }
+}
+
+//대댓글 삭제
+export async function deleteRecomment({ id }: { id: number }) {
+  try {
+    const response = await api.delete(`recomments/${id}`, {
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+    });
+    return response.data;
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
+  }
+}
+
+//대댓글 생성
+export async function postRecomment({
+  id,
+  content,
+}: {
+  id: number;
+  content: string;
+}) {
+  try {
+    const response = await api.post(
+      `/comments/${id}/recomments`,
+      {
+        content,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${getAccessToken()}`,
+        },
+      }
+    );
+    return response.data;
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
+  }
+}

--- a/kakaobase/src/components/inputs/CommentInput.tsx
+++ b/kakaobase/src/components/inputs/CommentInput.tsx
@@ -1,12 +1,15 @@
 import { postComment } from '@/apis/comment';
+import { postRecomment } from '@/apis/recomment';
 import { Send } from 'lucide-react';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useState } from 'react';
 
 export default function CommentInput() {
   const [comment, setComment] = useState('');
+  const path = usePathname();
   const param = useParams();
-  const id = Number(param.postId);
+  const postId = Number(param.postId);
+  const commentId = Number(param.commentId);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
@@ -14,8 +17,18 @@ export default function CommentInput() {
 
   const handleSubmit = async () => {
     if (!comment.trim()) return;
+    let response = {};
     try {
-      const response = await postComment({ postId: id, content: comment });
+      if (path.includes('comment')) {
+        response = await postComment({
+          postId,
+          content: comment,
+          parent_id: commentId,
+        });
+        console.log(response);
+      } else {
+        response = await postComment({ postId, content: comment });
+      }
       console.log(response);
     } catch (e: any) {
       console.log(e);

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -1,5 +1,6 @@
 import { deleteComment } from '@/apis/comment';
 import { deletePost } from '@/apis/post';
+import { deleteRecomment } from '@/apis/recomment';
 import { getClientCookie } from '@/lib/getClientCookie';
 import { PostType } from '@/lib/postType';
 import { usePathname, useRouter } from 'next/navigation';
@@ -16,7 +17,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
     try {
       if (type === 'post') await deletePost({ postType, id });
       else if (type === 'comment') await deleteComment({ id });
-      // else await deleteRecomment({id}); // 대댓글 삭제
+      else await deleteRecomment({ id }); // 대댓글 삭제
       setOpen(false);
       if (path.includes('post') && type === 'post')
         router.push('/'); //게시글 상세에서 게시글 지우기

--- a/kakaobase/src/hooks/post/usePostCardDetail.tsx
+++ b/kakaobase/src/hooks/post/usePostCardDetail.tsx
@@ -21,7 +21,7 @@ export default function usePostDetail({ id }: { id: number }) {
       setLoading(true);
       if (path.includes('comment')) {
         response = await getComment({ id });
-        setPost(mapToPostEntity(response, 'comment'));
+        setPost(mapToPostEntity(response.data.data, 'comment'));
       } else {
         response = await getPost({ postType, id });
         setPost(mapToPostEntity(response, 'post'));

--- a/kakaobase/src/hooks/post/usePostCardHook.tsx
+++ b/kakaobase/src/hooks/post/usePostCardHook.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import getPosts from '@/apis/postList';
 import { useParams, usePathname } from 'next/navigation';
 import getComments from '@/apis/commentList';
-import getRecomments from '@/apis/recomment';
+import { getRecomments } from '@/apis/recomment';
 import type { PostEntity } from '@/stores/postType';
 
 export default function usePosts(limit: number) {
@@ -16,16 +16,17 @@ export default function usePosts(limit: number) {
 
   const fetchPosts = useCallback(async () => {
     if (loading || !hasMore) return;
-    const id = Number(param.postId);
+    const postId = Number(param.postId);
+    const commentId = Number(param.commentId);
 
     try {
       setLoading(true);
       let data: PostEntity[] = [];
 
       if (path.includes('comment')) {
-        data = await getRecomments(id, { limit, cursor });
+        data = await getRecomments(commentId, { limit, cursor });
       } else if (path.includes('post')) {
-        data = await getComments(id, { limit, cursor });
+        data = await getComments(postId, { limit, cursor });
       } else {
         data = await getPosts({ limit, cursor });
       }

--- a/kakaobase/src/hooks/user/useLikeHook.tsx
+++ b/kakaobase/src/hooks/user/useLikeHook.tsx
@@ -1,8 +1,10 @@
 import {
   deleteCommentLike,
   deletePostLike,
+  deleteRecommentLike,
   likeComment,
   likePost,
+  likeRecomment,
 } from '@/apis/like';
 import { useState } from 'react';
 
@@ -32,6 +34,15 @@ export function useLikeToggle(
           setLikeCount((prev) => prev - 1);
         } else {
           const reponse = await likeComment({ id });
+          setLikeCount((prev) => prev + 1);
+        }
+      } else {
+        if (isLiked) {
+          const reponse = await deleteRecommentLike({ id });
+
+          setLikeCount((prev) => prev - 1);
+        } else {
+          const reponse = await likeRecomment({ id });
           setLikeCount((prev) => prev + 1);
         }
       }

--- a/kakaobase/src/lib/mapPost.tsx
+++ b/kakaobase/src/lib/mapPost.tsx
@@ -33,7 +33,7 @@ export function mapToPostEntity(post: any, type: PostType): PostEntity {
   if (type === 'comment') {
     return {
       ...base,
-      commentCount: post.comment_count,
+      commentCount: post.recomment_count,
     } as Comment;
   }
 


### PR DESCRIPTION
- 대댓글 작성 구현 : getComment.tsx
    - 댓글 작성 api와 동일함
- CommentInput에서 대댓글 작성과 댓글 작성 조건문으로 분리하여 대댓글 작성 구현
    - 비즈니스 로직과 분리가 필요
- useDeleteHook : 대댓글 삭제 주석 제거
- 댓글 응답 형태 매핑하는 객체 수정 : usePostCardDetail
- usePostCard : 대댓글 목록 조회
- useLikeHook : 대댓글 좋아요 등록 / 취소 로직 조건문에 추가
- 댓글 - postEntity 매핑할 때 대댓글 수 매핑 속성 수정
    - 근데 아직 백엔드 확인 못 함
    - 응답이 우선 recomment_count로 오는 걸로 알고 있음

- 대댓글 api 구현
    - 대댓글 목록 조회
    - 대댓글 삭제
    - 대댓글 생성