### PR TITLE
[FIX] 게시글 글자 수 분기처리

### DIFF
--- a/kakaobase/src/components/post/PostCard.tsx
+++ b/kakaobase/src/components/post/PostCard.tsx
@@ -33,12 +33,17 @@ export default function PostCard({ post }: { post: PostEntity }) {
         <div className="w-full flex flex-col gap-2 text-textColor">
           <UserInfo post={post} />
           <div onClick={navDetail}>
-            {post.content ? (
-              <div className="w-full text-sm overflow-hidden cursor-pointer line-clamp-2 text-ellipsis">
-                {post.content}
-              </div>
-            ) : null}
-
+            {!path.includes('post')
+              ? post.content && (
+                  <div className="w-full text-sm overflow-hidden cursor-pointer line-clamp-2 text-ellipsis">
+                    {post.content}
+                  </div>
+                )
+              : post.content && (
+                  <div className="w-full text-sm overflow-hidden cursor-pointer">
+                    {post.content}
+                  </div>
+                )}
             <div className="flex justify-center content-center w-full overflow-hidden rounded-lg">
               {post.type === 'post' && 'imageUrl' in post && post.imageUrl && (
                 <Image


### PR DESCRIPTION
- 메인 페이지 게시글은 2줄만 보이게
- 상세 페이지 하위 페이지들은 전부 보이게

close #84 