### PR TITLE
[FEAT] 게시글 종류 선택

### DIFF
--- a/kakaobase/src/apis/postList.tsx
+++ b/kakaobase/src/apis/postList.tsx
@@ -6,26 +6,26 @@ import { mapToPostEntity } from '@/lib/mapPost';
 export interface GetPostsParams {
   limit?: number;
   cursor?: number;
-  id?: number;
+  course?: string;
 }
 
 export default async function getPosts({
   limit,
   cursor,
+  course,
 }: GetPostsParams): Promise<Post[]> {
   try {
-    let postType = getClientCookie('course');
-    if (!postType) postType = 'ALL';
-
     const params: Record<string, any> = {};
     if (limit !== undefined) params.limit = limit;
     if (cursor !== undefined) params.cursor = cursor;
-    const response = await api.get(`/posts/${postType}`, {
+
+    const response = await api.get(`/posts/${course}`, {
       params,
       headers: {
         Authorization: `Bearer ${getClientCookie('accessToken')}`,
       },
     });
+
     return response.data.data.map((p: any) => mapToPostEntity(p, 'post'));
   } catch (e: unknown) {
     if (e instanceof Error) throw e;

--- a/kakaobase/src/app/page.tsx
+++ b/kakaobase/src/app/page.tsx
@@ -7,9 +7,9 @@ export default function Home() {
   return (
     <main className="flex flex-col h-screen scroll-none ">
       <HeaderMain />
-      {/* <PostCourseSelector /> */}
+      <PostCourseSelector />
       <div
-        className="flex overflow-y-auto flex-grow flex-col mb-16 my-20"
+        className="flex overflow-y-auto flex-grow flex-col mb-16"
         data-scroll-area
       >
         <PostList />

--- a/kakaobase/src/components/post/PostCourseSelector.tsx
+++ b/kakaobase/src/components/post/PostCourseSelector.tsx
@@ -1,13 +1,25 @@
+'use client';
+
+import useCourseSelectHook from '@/hooks/post/useCourseSelectHook';
+
 export default function PostCourseSelector() {
+  const { course, myCourseLabel, handleChange } = useCourseSelectHook();
+
   return (
-    <div className="border-b-[1px] border-textOpacity50 px-6 py-6 bg-bgColor">
+    <div className="border-b-[1px] shadow-sm px-6 py-6 mt-20 bg-bgColor text-textColor">
       <select
         name="post-course"
         className="bg-transparent focus:outline-none font-bold"
-        defaultValue="카카오테크 부트캠프 2기"
+        value={course}
+        onChange={handleChange}
+        defaultValue={course}
       >
-        <option>전체</option>
-        <option>카카오테크 부트캠프 2기</option>
+        <option value="ALL">기타 사용자</option>
+        {localStorage.getItem('myCourse') !== 'ALL' && (
+          <option value={localStorage.getItem('myCourse') || 'ALL'}>
+            {myCourseLabel}
+          </option>
+        )}
       </select>
     </div>
   );

--- a/kakaobase/src/components/post/PostList.tsx
+++ b/kakaobase/src/components/post/PostList.tsx
@@ -5,19 +5,23 @@ import usePosts from '@/hooks/post/usePostCardHook';
 import PostCard from './PostCard';
 import { usePathname, useRouter } from 'next/navigation';
 import Loading from '../common/loading/Loading';
+import useCourseSelectHook from '@/hooks/post/useCourseSelectHook';
 
 export default function PostList() {
   const path = usePathname();
-  const { posts, loading, error, hasMore, fetchPosts } = usePosts(6);
+  const router = useRouter();
   const observerRef = useRef<HTMLDivElement | null>(null);
   const [touchStartY, setTouchStartY] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const router = useRouter();
 
-  // 마운트 시 한 번만 호출
+  const { course } = useCourseSelectHook();
+
+  // usePosts는 course를 deps로 사용
+  const { posts, loading, error, hasMore, fetchPosts } = usePosts(6, course);
+
   useEffect(() => {
-    fetchPosts();
-  }, []);
+    fetchPosts(true); // course 변경 시 reset
+  }, [course]);
 
   // 무한 스크롤 옵저버
   useEffect(() => {

--- a/kakaobase/src/hooks/post/useCourseSelectHook.tsx
+++ b/kakaobase/src/hooks/post/useCourseSelectHook.tsx
@@ -1,0 +1,41 @@
+import { courseMapReverse } from '@/lib/courseMap';
+import { useEffect, useState } from 'react';
+
+export default function useCourseSelectHook() {
+  const [course, setCourse] = useState<string>(
+    localStorage.getItem('currCourse') || 'ALL'
+  );
+  const [myCourseLabel, setMyCourseLabel] = useState('기타 사용자');
+
+  useEffect(() => {
+    const curr = localStorage.getItem('currCourse');
+    const myCourse = localStorage.getItem('myCourse');
+
+    if (curr) setCourse(curr);
+
+    if (myCourse) {
+      setMyCourseLabel(courseMapReverse[myCourse]); //한국어로 매핑
+    } else {
+      setMyCourseLabel('기타 사용자');
+    }
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const stored =
+        localStorage.getItem('currCourse') ||
+        localStorage.getItem('myCourse') ||
+        'ALL';
+      setCourse((prev) => (prev !== stored ? stored : prev));
+    }, 0);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCourse = e.target.value;
+    setCourse(newCourse);
+    localStorage.setItem('currCourse', newCourse);
+  };
+
+  return { myCourseLabel, handleChange, course };
+}

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -1,13 +1,12 @@
 import { deleteComment } from '@/apis/comment';
 import { deletePost } from '@/apis/post';
 import { deleteRecomment } from '@/apis/recomment';
-import { getClientCookie } from '@/lib/getClientCookie';
 import { PostType } from '@/lib/postType';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export function useDeleteHook({ id, type }: { id: number; type: string }) {
-  let postType = getClientCookie('course') as PostType;
+  let postType = localStorage.getItem('currCourse') as PostType;
   if (!postType) postType = 'ALL';
 
   const router = useRouter();

--- a/kakaobase/src/hooks/post/usePostCardHook.tsx
+++ b/kakaobase/src/hooks/post/usePostCardHook.tsx
@@ -5,7 +5,7 @@ import getComments from '@/apis/commentList';
 import { getRecomments } from '@/apis/recomment';
 import type { PostEntity } from '@/stores/postType';
 
-export default function usePosts(limit: number) {
+export default function usePosts(limit: number, course: string) {
   const [posts, setPosts] = useState<PostEntity[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -41,7 +41,7 @@ export default function usePosts(limit: number) {
         } else if (path.includes('post')) {
           data = await getComments(postId, { limit, cursor: currentCursor });
         } else {
-          data = await getPosts({ limit, cursor: currentCursor });
+          data = await getPosts({ limit, cursor: currentCursor, course });
         }
 
         if (reset) {
@@ -61,7 +61,7 @@ export default function usePosts(limit: number) {
         setLoading(false);
       }
     },
-    [loading, limit, cursor, path, param]
+    [loading, limit, cursor, path, param, course]
   );
 
   return { posts, loading, error, hasMore, fetchPosts };

--- a/kakaobase/src/hooks/post/usePostEditorForm.tsx
+++ b/kakaobase/src/hooks/post/usePostEditorForm.tsx
@@ -1,6 +1,5 @@
 import postToS3 from '@/apis/imageS3';
 import { postPost } from '@/apis/post';
-import { getClientCookie } from '@/lib/getClientCookie';
 import { PostType } from '@/lib/postType';
 import { postSchema } from '@/schemas/postSchema';
 import { usePostStore } from '@/stores/postStore';
@@ -31,7 +30,7 @@ export const usePostEditorForm = () => {
   });
 
   const onSubmit = async (data: NewPostData) => {
-    let postType = getClientCookie('course') as PostType;
+    let postType = localStorage.getItem('currCourse') as PostType;
     if (!postType) postType = 'ALL';
 
     try {
@@ -51,7 +50,6 @@ export const usePostEditorForm = () => {
         }
       );
 
-      console.log('게시글 등록 성공');
       router.push(`/`);
     } catch (e: any) {
       console.log('게시글 업로드 실패:', e);

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -39,13 +39,13 @@ export default function useLoginForm() {
     try {
       const response = await login(requestBody);
       document.cookie = `accessToken=${response.data.access_token}; path=/; secure; samesite=strict; max-age=1800`; //30분
-      document.cookie = `course=${response.data.class_name}; path=/; max-age=1209600`; //refresh Token이랑 기간 동일하게 14일
-      document.cookie = `nickname=${response.data.nickname}; path=/; max-age=1209600`;
+      localStorage.setItem('myCourse', response.data.class_name);
+      localStorage.setItem('nickname', response.data.nickname);
 
       if (autoLogin) {
-        document.cookie = `autoLogin=true; path=/; max-age=1209600`;
+        localStorage.setItem('autoLogin', 'true');
       } else {
-        document.cookie = `autoLogin=false; path=/; max-age=0`; // 삭제
+        localStorage.setItem('autoLogin', 'false');
       }
       setUserInfo({
         course: response.data.class_name,
@@ -54,7 +54,6 @@ export default function useLoginForm() {
       });
       router.push('/');
     } catch (e: any) {
-      console.log(e.response.data);
       if (e.response.data.error === 'invalid_password') {
         setError('password', {
           type: 'manual',

--- a/kakaobase/src/lib/courseMap.tsx
+++ b/kakaobase/src/lib/courseMap.tsx
@@ -5,3 +5,7 @@ export const courseMap: Record<string, string> = {
   '카카오테크 부트캠프 2기': 'PANGYO_2',
   '기타 사용자': 'ALL',
 };
+
+export const courseMapReverse: Record<string, string> = Object.fromEntries(
+  Object.entries(courseMap).map(([key, value]) => [value, key])
+);


### PR DESCRIPTION
- 로그인에서 course 및 토큰 이외 기타 응답 속성들을 쿠키에 저장하지 않고 localStorage에 저장하는 것으로 변경
- 메인 페이지에서 PostCourseSelector 활성화
- 실제 PostCourseSelector에 더미 값이 아닌 사용자의 course에 맞게 선택하고 보이도록 변경
- PostCourseSelector, PostList 두 개가 서로 연결돼야 하기 때문에 course 훅 작성 및 지역변수로 관리하여 연결
- 게시글 삭제/등록에서 쿠키가 아닌 localStorage에서 course를 가져오도록 설정
- 게시글 목록 조회하는 postCardHook에서 course 의존성 및 매개변수 추가