### PR TITLE
[FEAT] 프로필 편집 구현

### DIFF
--- a/kakaobase/src/apis/editProfile.tsx
+++ b/kakaobase/src/apis/editProfile.tsx
@@ -1,0 +1,17 @@
+import { getClientCookie } from '@/lib/getClientCookie';
+import api from './api';
+
+export default async function editProfile({ imageUrl }: { imageUrl: string }) {
+  const accessToken = getClientCookie('accessToken');
+  try {
+    const response = await api.put('/users/images', {
+      image_url: imageUrl,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    console.log(response);
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
+  }
+}

--- a/kakaobase/src/apis/login.tsx
+++ b/kakaobase/src/apis/login.tsx
@@ -11,6 +11,7 @@ interface LoginResponse {
     access_token: string;
     class_name: string;
     nickname: string;
+    image_url: string;
   };
 }
 

--- a/kakaobase/src/app/profile/[userId]/edit/page.tsx
+++ b/kakaobase/src/app/profile/[userId]/edit/page.tsx
@@ -1,7 +1,15 @@
+import Header from '@/components/common/header/Header';
+import NavBar from '@/components/common/NavBar';
+import Wrapper from '@/components/profile/edit/Wrapper';
+
 export default function Page() {
   return (
     <div>
-      <div>프로필 편집 (깃허브, 프로필 이미지) 페이지입니다.</div>
+      <div>
+        <Header label="프로필 편집" />
+        <Wrapper />
+        <NavBar />
+      </div>
     </div>
   );
 }

--- a/kakaobase/src/components/common/loading/LoadingSmall.tsx
+++ b/kakaobase/src/components/common/loading/LoadingSmall.tsx
@@ -2,9 +2,9 @@ import { LoaderCircle } from 'lucide-react';
 
 export default function LoadingSmall() {
   return (
-    <div className="text-xs flex justify-center text-center items-center gap-4 text-textColor">
-      <LoaderCircle width={12} height={12} className="animate-spin" /> 로딩
-      중...
+    <div className="text-xs flex flex-col justify-center text-center items-center gap-2 text-textColor">
+      <LoaderCircle width={12} height={12} className="animate-spin" />
+      <div>로딩 중...</div>
     </div>
   );
 }

--- a/kakaobase/src/components/profile/edit/ImageInput.tsx
+++ b/kakaobase/src/components/profile/edit/ImageInput.tsx
@@ -1,0 +1,35 @@
+import { CirclePlus } from 'lucide-react';
+import Image from 'next/image';
+
+export default function ImageInput() {
+  return (
+    <div>
+      <label
+        htmlFor="image-upload"
+        className="flex relative gap-2 items-center justify-center cursor-pointer"
+      >
+        <Image
+          src="/logo_square.svg"
+          width={60}
+          height={60}
+          alt="프로필 이미지"
+          className="block"
+        />
+        <div className="w-full aspect-[1/1] bg-textOpacity50 absolute flex rounded-lg justify-center">
+          <CirclePlus className="w-4 text-textColor self-center" />
+        </div>
+      </label>
+
+      <input
+        id="image-upload"
+        type="file"
+        accept="image/png, image/jpeg, image/jpg, image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          //이미지 세팅
+        }}
+      />
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/edit/ImageInput.tsx
+++ b/kakaobase/src/components/profile/edit/ImageInput.tsx
@@ -1,22 +1,57 @@
+import LoadingSmall from '@/components/common/loading/LoadingSmall';
+import { imageData } from '@/hooks/profile/useImageEditHook';
 import { CirclePlus } from 'lucide-react';
 import Image from 'next/image';
+import { UseFormHandleSubmit, UseFormSetValue } from 'react-hook-form';
 
-export default function ImageInput() {
+interface ImageInputProps {
+  setValue: UseFormSetValue<imageData>;
+  handleSubmit: UseFormHandleSubmit<imageData>;
+  onSubmit: (data: imageData) => Promise<void>;
+  loading: boolean;
+  image: string | null;
+}
+
+export default function ImageInput({
+  setValue,
+  handleSubmit,
+  onSubmit,
+  loading,
+  image,
+}: ImageInputProps) {
+  function handleImage(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      setValue('imageFile', file, { shouldValidate: true });
+      const url = URL.createObjectURL(file);
+      handleSubmit(onSubmit)();
+      console.log(image);
+    }
+  }
+
   return (
     <div>
       <label
         htmlFor="image-upload"
         className="flex relative gap-2 items-center justify-center cursor-pointer"
       >
-        <Image
-          src="/logo_square.svg"
-          width={60}
-          height={60}
-          alt="프로필 이미지"
-          className="block"
-        />
+        {!image || image === 'null' ? (
+          <div className="w-16 h-16 block bg-textOpacity50 rounded-lg"></div>
+        ) : (
+          <Image
+            src={image}
+            width={64}
+            height={64}
+            alt="프로필 이미지"
+            className="block rounded-lg"
+          />
+        )}
         <div className="w-full aspect-[1/1] bg-textOpacity50 absolute flex rounded-lg justify-center">
-          <CirclePlus className="w-4 text-textColor self-center" />
+          {loading ? (
+            <LoadingSmall />
+          ) : (
+            <CirclePlus className="w-4 text-textColor self-center" />
+          )}
         </div>
       </label>
 
@@ -25,10 +60,7 @@ export default function ImageInput() {
         type="file"
         accept="image/png, image/jpeg, image/jpg, image/webp"
         className="hidden"
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          //이미지 세팅
-        }}
+        onChange={handleImage}
       />
     </div>
   );

--- a/kakaobase/src/components/profile/edit/ReadOnlyUserInfo.tsx
+++ b/kakaobase/src/components/profile/edit/ReadOnlyUserInfo.tsx
@@ -1,0 +1,14 @@
+export default function ReadOnlyUserInfo({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex flex-col text-textColor">
+      <div className="flex text-sm">{label}</div>
+      <div className="flex text-xs">{value}</div>
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/edit/RoutingButtons.tsx
+++ b/kakaobase/src/components/profile/edit/RoutingButtons.tsx
@@ -1,0 +1,18 @@
+import SubmitButton from '@/components/common/button/SubmitButton';
+import { useRouter } from 'next/navigation';
+
+export default function RoutingButtons() {
+  const router = useRouter();
+  function navPasswordEdit() {
+    router.push('edit/password');
+  }
+  function navWithdraw() {
+    router.push('edit/withdraw');
+  }
+  return (
+    <div className="flex gap-6">
+      <SubmitButton text="비밀번호 변경하기" onClick={navPasswordEdit} />
+      <SubmitButton text="회원 탈퇴하기" onClick={navWithdraw} />
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/edit/TopArea.tsx
+++ b/kakaobase/src/components/profile/edit/TopArea.tsx
@@ -1,0 +1,17 @@
+import ReadOnlyUserInfo from './ReadOnlyUserInfo';
+import ImageInput from './ImageInput';
+
+export default function TopArea() {
+  return (
+    <div className="flex flex-col w-full">
+      <div className="text-xs text-redHeart">helpertext</div>
+      <div className="flex gap-4">
+        <ImageInput />
+        <div className="flex flex-col gap-3">
+          <ReadOnlyUserInfo label="이름" value="daisy.kim(김도현)" />
+          <ReadOnlyUserInfo label="과정명" value="카카오테크 부트캠프 2기" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/edit/TopArea.tsx
+++ b/kakaobase/src/components/profile/edit/TopArea.tsx
@@ -1,12 +1,32 @@
+'use client';
+
 import ReadOnlyUserInfo from './ReadOnlyUserInfo';
 import ImageInput from './ImageInput';
+import useImageEditHook from '@/hooks/profile/useImageEditHook';
 
 export default function TopArea() {
+  const {
+    loading,
+    handleSubmit,
+    formState: { errors },
+    onSubmit,
+    setValue,
+    previewUrl,
+  } = useImageEditHook();
+
   return (
     <div className="flex flex-col w-full">
-      <div className="text-xs text-redHeart">helpertext</div>
-      <div className="flex gap-4">
-        <ImageInput />
+      <div className="text-[0.625rem] text-redHeart h-4">
+        {errors.imageFile?.message || ''}
+      </div>
+      <div className="flex gap-4 items-center">
+        <ImageInput
+          onSubmit={onSubmit}
+          handleSubmit={handleSubmit}
+          setValue={setValue}
+          loading={loading}
+          image={previewUrl}
+        />
         <div className="flex flex-col gap-3">
           <ReadOnlyUserInfo label="이름" value="daisy.kim(김도현)" />
           <ReadOnlyUserInfo label="과정명" value="카카오테크 부트캠프 2기" />

--- a/kakaobase/src/components/profile/edit/Wrapper.tsx
+++ b/kakaobase/src/components/profile/edit/Wrapper.tsx
@@ -1,0 +1,20 @@
+'use client';
+import SubmitButtonSmall from '@/components/common/button/SubmitButtonSmall';
+import UserInput from '@/components/inputs/UserInput';
+import RoutingButtons from './RoutingButtons';
+import TopArea from './TopArea';
+
+export default function Wrapper() {
+  return (
+    <div className="flex justify-center items-center animate-slide-in flex-col">
+      <div className="flex bg-containerColor px-8 py-10 rounded-xl flex flex-col items-center gap-8">
+        <TopArea />
+        <div className="flex items-center gap-4 w-full">
+          <UserInput label="깃허브 링크" errorMessage="asdf" />
+          <SubmitButtonSmall label="저장" />
+        </div>
+        <RoutingButtons />
+      </div>
+    </div>
+  );
+}

--- a/kakaobase/src/hooks/profile/useImageEditHook.tsx
+++ b/kakaobase/src/hooks/profile/useImageEditHook.tsx
@@ -1,0 +1,66 @@
+import { profileImageSchema } from '@/schemas/profileImageSchema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import useTokenCheck from '../user/useTokenCheckHook';
+import { useEffect, useState } from 'react';
+import postToS3 from '@/apis/imageS3';
+import editProfile from '@/apis/editProfile';
+import { refreshToken } from '@/apis/login';
+
+export type imageData = z.infer<typeof profileImageSchema>;
+
+export default function useImageEditHook() {
+  const { checkUnauthorized } = useTokenCheck();
+  const [loading, setLoading] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPreviewUrl(localStorage.getItem('profile'));
+  }, []);
+
+  const methods = useForm<imageData>({
+    resolver: zodResolver(profileImageSchema),
+    mode: 'all',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      imageFile: undefined,
+    },
+  });
+
+  const onSubmit = async (data: imageData) => {
+    checkUnauthorized();
+
+    try {
+      setLoading(true);
+      let imageUrl = '';
+      if (data.imageFile) {
+        imageUrl = await postToS3(data.imageFile, 'profile_image');
+      } //이미지 잘 옴
+
+      setPreviewUrl(imageUrl);
+      console.log('미리보기 이미지 수정 완료');
+      localStorage.setItem('profile', imageUrl);
+      console.log('로컬 스토리지에 프로필 저장 완료');
+
+      await editProfile({ imageUrl }); //이거 지금 안 됨
+      alert('프로필 이미지 저장 완료');
+    } catch (e: any) {
+      console.log('이미지 등록 안 됨', e.response);
+      methods.setError('imageFile', {
+        message: '프로필 이미지 저장 실패',
+      });
+      if (e.response?.data.error === 'unauthorized') {
+        //로그인 했는데 이거 뜸
+        refreshToken();
+      } else {
+        alert(
+          '프로필 이미지 업로드 실패 : 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.'
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+  return { onSubmit, loading, ...methods, previewUrl };
+}

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -34,6 +34,7 @@ export default function useLoginForm() {
       document.cookie = `accessToken=${response.data.access_token}; path=/; secure; samesite=lax; max-age=1800`; //30분
       localStorage.setItem('myCourse', response.data.class_name);
       localStorage.setItem('nickname', response.data.nickname);
+      localStorage.setItem('profile', response.data.image_url);
 
       if (autoLogin) {
         localStorage.setItem('autoLogin', 'true');

--- a/kakaobase/src/schemas/profileImageSchema.tsx
+++ b/kakaobase/src/schemas/profileImageSchema.tsx
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const FILE_SIZE = 10 * 1024 * 1024;
+
+export const profileImageSchema = z.object({
+  imageFile: z
+    .instanceof(File)
+    .optional()
+    .refine((file) => !file || /\.(png|jpeg|jpg|webp)$/i.test(file.name), {
+      message: '이미지 파일 형식은 png, jpg, jpeg, webp만 가능합니다.',
+    })
+    .refine((file) => !file || file.size <= FILE_SIZE, {
+      message: '파일 크기는 최대 10MB입니다.',
+    }),
+});


### PR DESCRIPTION
## ui 구조 완료
- 프로필 이미지 컴포넌트
- 읽기 전용 사용자 정보 (이름, 과정명)
- 페이지 이동 버튼 컴포넌트

## 프로필 이미지 등록 로직
- 스키마 작성 완료
- 이미지 등록 hook 작성 완료
- TopArea 컴포넌트에 hook 호출 및 props 전달
- ImageInput 컴포넌트에서 이미지 등록 로직 추가
- 토스트 메시지는 추후 구현
- 프로필 이미지 수정 api 작성

## 추가 변경 사항
### 다른 컴포넌트 일부 수정
- 로그인 프로필 이미지 - localStorage
- 로딩 중 ui 일부 수정
- 게시글 등록 시 액세스 토큰 확인 로직 일부 수정

## 비고
- 스웨거에 아직 프로필 이미지 등록 api가 올라오지 않음
- 깃허브 url 수정api도 올라오지 않아 #114 - api 관련 이슈 파서 진행 예정