### PR TITLE
[FEAT] 마이페이지 ui 구현

### DIFF
--- a/kakaobase/src/apis/login.tsx
+++ b/kakaobase/src/apis/login.tsx
@@ -12,6 +12,7 @@ interface LoginResponse {
     class_name: string;
     nickname: string;
     image_url: string;
+    member_id: string;
   };
 }
 

--- a/kakaobase/src/app/profile/[userId]/page.tsx
+++ b/kakaobase/src/app/profile/[userId]/page.tsx
@@ -1,9 +1,12 @@
+import Header from '@/components/common/header/Header';
 import NavBar from '@/components/common/NavBar';
+import Wrapper from '@/components/profile/Wrapper';
 
 export default function Page() {
   return (
     <div className="flex flex-col h-screen">
-      <div className="flex-grow">마이 페이지 / BASE페이지 입니다.</div>
+      <Header label="프로필" />
+      <Wrapper />
       <NavBar />
     </div>
   );

--- a/kakaobase/src/components/common/NavBar.tsx
+++ b/kakaobase/src/components/common/NavBar.tsx
@@ -32,32 +32,48 @@ function NavItem({ icon: Icon, path }: { icon: LucideIcon; path?: string }) {
   );
 }
 
-function LoginProfile() {
+function LoginProfile({ path }: { path: string }) {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [userId, setUserId] = useState('');
+  const pathName = usePathname();
+  const router = useRouter();
+
+  const isActive = pathName.includes(path);
 
   useEffect(() => {
-    const url = localStorage.getItem('profileImage') || '';
+    const url = localStorage.getItem('profile') || '';
     setImageUrl(url);
+    const id = localStorage.getItem('userId') || '';
+    setUserId(id);
   }, []);
 
-  if (imageUrl === null) return null; // hydration mismatch 방지
-  if (imageUrl === '') {
-    return (
-      <div className="flex">
-        <NavItem icon={User} />
-      </div>
-    );
+  function navMyProfile() {
+    router.push(`/profile/${userId}`);
   }
 
+  if (imageUrl === null) return null; // hydration mismatch 방지
+
   return (
-    <div className="flex">
-      <Image
-        src={imageUrl}
-        width={12}
-        height={12}
-        alt="profile"
-        className="w-6 h-6 rounded-md transition-colors cursor-pointer"
-      />
+    <div className="flex" onClick={navMyProfile}>
+      {imageUrl === '' || imageUrl === 'null' ? (
+        <User
+          className={clsx(
+            'w-6 h-6 transition-colors cursor-pointer',
+            isActive ? 'text-myBlue' : 'text-iconColor'
+          )}
+        />
+      ) : (
+        <Image
+          src={imageUrl}
+          width={12}
+          height={12}
+          alt="profile"
+          className={clsx(
+            'w-6 h-6 transition-colors cursor-pointer rounded-md',
+            isActive ? 'text-myBlue' : 'text-iconColor'
+          )}
+        />
+      )}
     </div>
   );
 }
@@ -90,7 +106,11 @@ export default function NavBar() {
         </button>
         <div className="flex gap-12">
           {/* <NavItem icon={Bell} path="/alarm" /> */}
-          {hasToken ? <LoginProfile /> : <NavItem icon={User} path="/login" />}
+          {hasToken ? (
+            <LoginProfile path="/profile" />
+          ) : (
+            <NavItem icon={User} path="/login" />
+          )}
         </div>
       </div>
     </div>

--- a/kakaobase/src/components/common/button/SubmitButton.tsx
+++ b/kakaobase/src/components/common/button/SubmitButton.tsx
@@ -24,7 +24,7 @@ export default function SubmitButton({
             : 'bg-myBlue text-textOnBlue'
         }`}
       >
-        {isLoading ? <LoadingSmall /> : <div className="text-xs">{text}</div>}
+        {isLoading ? <LoadingSmall /> : <div className="text-sm">{text}</div>}
       </div>
     </button>
   );

--- a/kakaobase/src/components/profile/CountInfo.tsx
+++ b/kakaobase/src/components/profile/CountInfo.tsx
@@ -1,0 +1,18 @@
+function CountItem({ label, count }: { label: string; count: string }) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="font-bold">{label}</div>
+      <div>{count}</div>
+    </div>
+  );
+}
+
+export default function CountInfo() {
+  return (
+    <div className="flex text-sm gap-4">
+      <CountItem label="게시글" count="10" />
+      <CountItem label="팔로워" count="12" />
+      <CountItem label="팔로잉" count="14" />
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/Toggle.tsx
+++ b/kakaobase/src/components/profile/Toggle.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+import { useState } from 'react';
+
+type profilePageList = '게시글' | '댓글' | '좋아요';
+
+function Button({
+  label,
+  type,
+  setType,
+}: {
+  label: profilePageList;
+  type: profilePageList;
+  setType: (type: profilePageList) => void;
+}) {
+  return (
+    <div
+      className={clsx(
+        'rounded-full cursor-pointer',
+        type === label
+          ? 'bg-myBlue text-textOnBlue'
+          : 'text-textColor hover:bg-textOpacity50'
+      )}
+      onClick={() => setType(label)}
+    >
+      <div className="text-sm px-4 py-1">{label}</div>
+    </div>
+  );
+}
+
+export default function Toggle() {
+  const [type, setType] = useState<profilePageList>('게시글');
+  const [isMe, setIsMe] = useState(true);
+
+  return (
+    <div className="flex gap-2 bg-containerColor px-1 py-1 rounded-full">
+      <Button label="게시글" type={type} setType={setType} />
+      <Button label="댓글" type={type} setType={setType} />
+      {isMe && <Button label="좋아요" type={type} setType={setType} />}
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/UserInfo.tsx
+++ b/kakaobase/src/components/profile/UserInfo.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { User } from 'lucide-react';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+
+export default function UserInfo() {
+  const [image, setImage] = useState('');
+  useEffect(() => {
+    const imageUrl = localStorage.getItem('profile');
+    if (imageUrl) setImage(imageUrl);
+  }, []);
+  return (
+    <div className="flex bg-containerColor px-8 py-4 my-4 rounded-xl flex flex-col items-center gap-4 w-full max-w-sm">
+      {image === '' || image === 'null' ? (
+        <User width={120} height={120} className="rounded-xl" />
+      ) : (
+        <Image
+          alt="프로필 이미지"
+          width={120}
+          height={120}
+          src={image}
+          className="rounded-xl"
+        />
+      )}
+      <div className="flex flex-col items-center">
+        <div className="font-bold">김도현</div>
+        <div className="text-sm">daisy.kim</div>
+      </div>
+      <div className="text-sm">
+        <div>카카오테크 부트캠프 2기</div>
+        <a
+          href="https://github.com/okiidokim"
+          className="cursor-pointer underline"
+        >
+          github.com/okiidokim
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/kakaobase/src/components/profile/Wrapper.tsx
+++ b/kakaobase/src/components/profile/Wrapper.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import SubmitButton from '../common/button/SubmitButton';
+import CountInfo from './CountInfo';
+import UserInfo from './UserInfo';
+import { useEffect, useState } from 'react';
+import Toggle from './Toggle';
+import PostList from '../post/list/PostList';
+import ListRouter from '../post/ListRouter';
+
+export default function Wrapper() {
+  const router = useRouter();
+  const [userId, setUserId] = useState('');
+  useEffect(() => {
+    const id = localStorage.getItem('userId');
+    if (id) setUserId(id);
+  });
+  function navEdit() {
+    router.push(`${userId}/edit`);
+  }
+  return (
+    <div className="flex flex-col items-center self-center text-textColor min-h-0 mb-[4rem] mt-[5rem] gap-4 ">
+      <UserInfo />
+      <CountInfo />
+      <div className="flex gap-4">
+        <SubmitButton text="프로필 편집" onClick={navEdit} />
+        <SubmitButton text="프로필 공유" />
+      </div>
+      <div className="flex flex-col gap-2 items-center min-h-0">
+        <Toggle />
+        <div
+          data-scroll-area
+          className="flex overflow-y-auto flex-grow flex-col"
+        >
+          <PostList />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -35,6 +35,7 @@ export default function useLoginForm() {
       localStorage.setItem('myCourse', response.data.class_name);
       localStorage.setItem('nickname', response.data.nickname);
       localStorage.setItem('profile', response.data.image_url);
+      localStorage.setItem('userId', response.data.member_id);
 
       if (autoLogin) {
         localStorage.setItem('autoLogin', 'true');


### PR DESCRIPTION
## 마이페이지 ui
- 마이페이지 ui 구현 완료
- navbar에서 프로필 클릭 시 라우팅 완료
- 프로필 편집 페이지로 라우팅 완료
- 게시글/댓글/좋아요 선택 토글

## 로그인 api 수정
- member_id 응답 추가
- 커스텀 훅 -> 로컬 스토리지 저장 수정

## SubmitButton 텍스트 크기 수정
- 더 크게 xs -> sm