### PR TITLE
[FEAT] 토스트 추가

### DIFF
--- a/kakaobase/src/apis/postList.tsx
+++ b/kakaobase/src/apis/postList.tsx
@@ -26,7 +26,6 @@ export default async function getPosts({
       },
     });
 
-    console.log(response.data.data);
     return response.data.data.map((p: any) => mapToPostEntity(p, 'post'));
   } catch (e: unknown) {
     if (e instanceof Error) throw e;

--- a/kakaobase/src/app/ToastContext.tsx
+++ b/kakaobase/src/app/ToastContext.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+} from 'react';
+
+interface ToastContextType {
+  showToast: (message: string) => void;
+  hideToast: () => void;
+  label: string;
+  isOpen: boolean;
+}
+
+const ToastContext = createContext<ToastContextType>({
+  showToast: () => {},
+  hideToast: () => {},
+  label: '',
+  isOpen: false,
+});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [label, setLabel] = useState('');
+
+  const showToast = useCallback((message: string) => {
+    setLabel(message);
+    setIsOpen(true);
+
+    setTimeout(() => setIsOpen(false), 2000);
+  }, []);
+
+  const hideToast = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast, hideToast, label, isOpen }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/kakaobase/src/app/providers.tsx
+++ b/kakaobase/src/app/providers.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
-import { useState } from 'react';
+import { ToastProvider } from './ToastContext';
+import Toast from '@/components/common/Toast';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,7 +16,12 @@ export const queryClient = new QueryClient({
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <ToastProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <Toast />
+        </QueryClientProvider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/kakaobase/src/components/common/Toast.tsx
+++ b/kakaobase/src/components/common/Toast.tsx
@@ -1,7 +1,38 @@
-export default function Toast() {
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function Toast({
+  show,
+  label,
+}: {
+  show: boolean;
+  label: string;
+}) {
+  const [isOpen, setOpen] = useState(false);
+
+  async function handleToast() {
+    setOpen(true);
+    setTimeout(() => setOpen(false), 2000);
+  }
+
+  useEffect(() => {
+    handleToast();
+  }, [show]);
+
+  if (!isOpen) return null;
+
   return (
-    <div>
-      <div>토스트 메시지 컴포넌트</div>
+    <div className="fixed inset-0 z-100 pointer-events-none">
+      <div className="flex mt-6">
+        <div className="hidden lg:flex flex-col w-[48%]"></div>
+        <div className="flex justify-center max-w-[480px] w-full mx-auto lg:ml-12 lg:self-start">
+          <div className="flex animate-slide-in bg-textColor rounded-lg shadow-md">
+            <div className="flex px-4 py-2">
+              <div className="text-bgColor">{label}</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/kakaobase/src/components/common/Toast.tsx
+++ b/kakaobase/src/components/common/Toast.tsx
@@ -1,23 +1,7 @@
-'use client';
-import { useEffect, useState } from 'react';
+import { useToast } from '@/app/ToastContext';
 
-export default function Toast({
-  show,
-  label,
-}: {
-  show: boolean;
-  label: string;
-}) {
-  const [isOpen, setOpen] = useState(false);
-
-  async function handleToast() {
-    setOpen(true);
-    setTimeout(() => setOpen(false), 2000);
-  }
-
-  useEffect(() => {
-    handleToast();
-  }, [show]);
+export default function Toast() {
+  const { isOpen, label } = useToast();
 
   if (!isOpen) return null;
 

--- a/kakaobase/src/components/post/UserInfo.tsx
+++ b/kakaobase/src/components/post/UserInfo.tsx
@@ -16,8 +16,10 @@ export function UserProfile({ post }: { post: PostEntity }) {
   return (
     <div
       className="flex w-8 h-7 rounded-lg bg-innerContainerColor justify-center items-center cursor-pointer"
-      onClick={(e) => e.stopPropagation()}
-      //onClick={navProfile}
+      onClick={(e) => {
+        e.stopPropagation();
+        navProfile();
+      }}
     >
       {post.userProfileUrl ? (
         <Image
@@ -64,7 +66,10 @@ export function UserInfo({ post }: { post: PostEntity }) {
       <div className="flex gap-2 items-center min-w-0">
         <div
           className="cursor-pointer font-bold text-sm overflow-hidden text-ellipsis whitespace-nowrap"
-          // onClick={navProfile}
+          onClick={(e) => {
+            e.stopPropagation();
+            navProfile();
+          }}
         >
           {post.nickname}
         </div>

--- a/kakaobase/src/components/profile/QR/CopyUrl.tsx
+++ b/kakaobase/src/components/profile/QR/CopyUrl.tsx
@@ -1,3 +1,4 @@
+import Toast from '@/components/common/Toast';
 import { useState } from 'react';
 
 export default function CopyUrl({ url }: { url: string }) {
@@ -22,8 +23,9 @@ export default function CopyUrl({ url }: { url: string }) {
         className="text-xs text-myBlue hover:underline"
         onClick={handleCopy}
       >
-        {copied ? '복사 완료!' : '복사'}
+        복사
       </button>
+      {copied && <Toast show={copied} label="복사 완료!" />}
     </div>
   );
 }

--- a/kakaobase/src/components/profile/QR/CopyUrl.tsx
+++ b/kakaobase/src/components/profile/QR/CopyUrl.tsx
@@ -1,19 +1,18 @@
-import Toast from '@/components/common/Toast';
-import { useState } from 'react';
+import { useToast } from '@/app/ToastContext';
 
 export default function CopyUrl({ url }: { url: string }) {
-  const [copied, setCopied] = useState<boolean>(false);
+  const { showToast } = useToast();
 
   const handleCopy = async () => {
     if (!url) return;
     try {
       await navigator.clipboard.writeText(url);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      showToast('복사 완료!');
     } catch (err) {
-      console.error('클립보드 복사 실패', err);
+      showToast('복사 실패 😭');
     }
   };
+
   return (
     <div className="flex w-full items-center justify-between rounded px-2 py-1 bg-innerContainerColor">
       <div className="truncate text-xs text-textColor" title={url}>
@@ -25,7 +24,6 @@ export default function CopyUrl({ url }: { url: string }) {
       >
         복사
       </button>
-      {copied && <Toast show={copied} label="복사 완료!" />}
     </div>
   );
 }

--- a/kakaobase/src/components/profile/edit/ImageInput.tsx
+++ b/kakaobase/src/components/profile/edit/ImageInput.tsx
@@ -25,7 +25,6 @@ export default function ImageInput({
       setValue('imageFile', file, { shouldValidate: true });
       const url = URL.createObjectURL(file);
       handleSubmit(onSubmit)();
-      console.log(image);
     }
   }
 

--- a/kakaobase/src/hooks/auth/useEmailAuth.tsx
+++ b/kakaobase/src/hooks/auth/useEmailAuth.tsx
@@ -5,6 +5,7 @@ import { loginSchema } from '@/schemas/loginSchema';
 import sendEmail from '@/apis/sendEmail';
 import { usePathname } from 'next/navigation';
 import postCodeVerification from '@/apis/verifyCode';
+import { useToast } from '@/app/ToastContext';
 
 export const useEmailAuth = () => {
   const pathName = usePathname();
@@ -13,6 +14,7 @@ export const useEmailAuth = () => {
   const [isEmailValid, setEmailValid] = useState(false);
   const [isCodeValid, setCodeValid] = useState(false);
   const [codeButtonLabel, setCodeButtonLabel] = useState('인증');
+  const { showToast } = useToast();
 
   const {
     verificationAttempts,
@@ -51,9 +53,10 @@ export const useEmailAuth = () => {
       setCodeValid(true);
     } catch (e: any) {
       timer.stop();
-      console.log(e);
       if (e.response.data.error === 'resource_alread_exists') {
         setError('*이미 가입된 이메일입니다.');
+      } else {
+        showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
       }
     }
   };
@@ -71,7 +74,6 @@ export const useEmailAuth = () => {
       setCodeButtonLabel('완료');
       timer.stop();
     } catch (e: any) {
-      console.log(e.response);
       if (e.response.data.error === 'email_code_invalid') {
         incrementAttempt();
         setCodeError(
@@ -81,6 +83,8 @@ export const useEmailAuth = () => {
       } else if (e.response.data.error === 'email_code_fail_logout') {
         setCodeError(`*인증에 실패하였습니다. 잠시 후 시도해 주세요.`);
         setVerified(false);
+      } else {
+        showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
       }
     }
   };

--- a/kakaobase/src/hooks/post/comment/useCommentForm.tsx
+++ b/kakaobase/src/hooks/post/comment/useCommentForm.tsx
@@ -1,5 +1,6 @@
 import { postComment } from '@/apis/comment';
 import { queryClient } from '@/app/providers';
+import { useToast } from '@/app/ToastContext';
 import { useParams, usePathname } from 'next/navigation';
 import { useState } from 'react';
 
@@ -9,6 +10,7 @@ export default function useCommentForm() {
   const param = useParams();
   const postId = Number(param.postId);
   const commentId = Number(param.commentId);
+  const { showToast } = useToast();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
@@ -29,7 +31,7 @@ export default function useCommentForm() {
         queryClient.invalidateQueries({ queryKey: ['comments'] });
       }
     } catch (e: any) {
-      console.log(e);
+      showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
     } finally {
       setComment('');
     }

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -30,7 +30,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
         queryClient.invalidateQueries({ queryKey: ['recomments'] });
       }
       setOpen(false);
-      showToast('삭제 완료!');
+      showToast('삭제 완료! ✌️');
       if (path.includes('post') && type === 'post')
         router.push('/'); //게시글 상세에서 게시글 지우기
       else if (path.includes('comment') && type === 'comment') router.back(); //댓글 상세에서 댓글 지우기
@@ -39,7 +39,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
       if (e.response.data.error === 'unauthorized') {
         refreshToken();
       } else {
-        showToast('문제 발생! 잠시 후 다시 시도해 주세요.');
+        showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
         router.push('/');
       }
       console.log(e);

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -3,6 +3,7 @@ import { refreshToken } from '@/apis/login';
 import { deletePost } from '@/apis/post';
 import { deleteRecomment } from '@/apis/recomment';
 import { queryClient } from '@/app/providers';
+import { useToast } from '@/app/ToastContext';
 import { PostType } from '@/lib/postType';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -11,6 +12,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
   const router = useRouter();
   const path = usePathname();
   const [isOpened, setOpen] = useState(false);
+  const { showToast } = useToast();
   async function deletePostExecute() {
     const postType =
       typeof window !== 'undefined'
@@ -28,6 +30,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
         queryClient.invalidateQueries({ queryKey: ['recomments'] });
       }
       setOpen(false);
+      showToast('삭제 완료!');
       if (path.includes('post') && type === 'post')
         router.push('/'); //게시글 상세에서 게시글 지우기
       else if (path.includes('comment') && type === 'comment') router.back(); //댓글 상세에서 댓글 지우기
@@ -36,7 +39,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
       if (e.response.data.error === 'unauthorized') {
         refreshToken();
       } else {
-        alert('문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+        showToast('문제 발생! 잠시 후 다시 시도해 주세요.');
         router.push('/');
       }
       console.log(e);

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -42,7 +42,6 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
         showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
         router.push('/');
       }
-      console.log(e);
     }
   }
   function closeModal() {

--- a/kakaobase/src/hooks/post/usePostDetailHook.tsx
+++ b/kakaobase/src/hooks/post/usePostDetailHook.tsx
@@ -6,11 +6,13 @@ import { usePathname, useRouter } from 'next/navigation';
 import { getComment } from '@/apis/comment';
 import { PostEntity } from '@/stores/postType';
 import { refreshToken } from '@/apis/login';
+import { useToast } from '@/app/ToastContext';
 
 export default function usePostDetail({ id }: { id: number }) {
   const [post, setPost] = useState<PostEntity>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const { showToast } = useToast();
   const path = usePathname();
   const router = useRouter();
 
@@ -33,8 +35,9 @@ export default function usePostDetail({ id }: { id: number }) {
       setError(e as Error);
       if (e.response.data.error === 'unauthorized') {
         refreshToken();
+        showToast('로그인이 필요합니다. 😭');
       } else {
-        alert('문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+        showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
         router.push('/');
       }
     } finally {

--- a/kakaobase/src/hooks/post/usePostEditorForm.tsx
+++ b/kakaobase/src/hooks/post/usePostEditorForm.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import useTokenCheck from '../user/useTokenCheckHook';
+import { useToast } from '@/app/ToastContext';
 
 export type NewPostData = z.infer<typeof postSchema>;
 
@@ -19,6 +20,7 @@ export const usePostEditorForm = () => {
   const content = usePostStore((state) => state.content);
   const youtubeUrl = usePostStore((state) => state.youtubeUrl);
   const imageUrl = usePostStore((state) => state.imageUrl);
+  const { showToast } = useToast();
   const [isLoading, setLoading] = useState(false);
   const { checkUnauthorized } = useTokenCheck();
 
@@ -53,16 +55,15 @@ export const usePostEditorForm = () => {
           youtube_url: data.youtubeUrl,
         }
       );
-
       await queryClient.invalidateQueries({ queryKey: ['posts'] });
+      showToast('게시글 등록 성공! ✌️');
       router.push(`/`);
     } catch (e: any) {
       if (e.response.data.error === 'unauthorized') {
         refreshToken();
+        showToast('로그인이 필요합니다. 😭');
       } else {
-        alert(
-          '게시글 업로드 실패 : 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.'
-        );
+        showToast('게시글 업로드 실패! 잠시 후 다시 시도해 주세요. 😭');
         router.push('/');
       }
     } finally {

--- a/kakaobase/src/hooks/profile/useImageEditHook.tsx
+++ b/kakaobase/src/hooks/profile/useImageEditHook.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import postToS3 from '@/apis/imageS3';
 import editProfile from '@/apis/editProfile';
 import { refreshToken } from '@/apis/login';
+import { useToast } from '@/app/ToastContext';
 
 export type imageData = z.infer<typeof profileImageSchema>;
 
@@ -14,6 +15,7 @@ export default function useImageEditHook() {
   const { checkUnauthorized } = useTokenCheck();
   const [loading, setLoading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   useEffect(() => {
     checkUnauthorized();
@@ -45,19 +47,18 @@ export default function useImageEditHook() {
       console.log('로컬 스토리지에 프로필 저장 완료');
 
       await editProfile({ imageUrl }); //이거 지금 안 됨
-      alert('프로필 이미지 저장 완료');
+      showToast('프로필 이미지 저장 완료! ✌️');
     } catch (e: any) {
       console.log('이미지 등록 안 됨', e.response);
       methods.setError('imageFile', {
-        message: '프로필 이미지 저장 실패',
+        message: '프로필 이미지 저장 실패 😭',
       });
       if (e.response?.data.error === 'unauthorized') {
         //로그인 했는데 이거 뜸
         refreshToken();
+        showToast('로그인이 필요합니다. 😭');
       } else {
-        alert(
-          '프로필 이미지 업로드 실패 : 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.'
-        );
+        showToast('프로필 이미지 업로드 실패! 잠시 후 다시 시도해 주세요. 😭');
       }
     } finally {
       setLoading(false);

--- a/kakaobase/src/hooks/profile/useImageEditHook.tsx
+++ b/kakaobase/src/hooks/profile/useImageEditHook.tsx
@@ -42,14 +42,11 @@ export default function useImageEditHook() {
       } //이미지 잘 옴
 
       setPreviewUrl(imageUrl);
-      console.log('미리보기 이미지 수정 완료');
       localStorage.setItem('profile', imageUrl);
-      console.log('로컬 스토리지에 프로필 저장 완료');
 
       await editProfile({ imageUrl }); //이거 지금 안 됨
       showToast('프로필 이미지 저장 완료! ✌️');
     } catch (e: any) {
-      console.log('이미지 등록 안 됨', e.response);
       methods.setError('imageFile', {
         message: '프로필 이미지 저장 실패 😭',
       });

--- a/kakaobase/src/hooks/profile/useWithdrawHook.tsx
+++ b/kakaobase/src/hooks/profile/useWithdrawHook.tsx
@@ -1,11 +1,13 @@
 import withdraw from '@/apis/withdraw';
 import { useEffect, useState } from 'react';
 import useTokenCheck from '../user/useTokenCheckHook';
+import { useToast } from '@/app/ToastContext';
 
 export default function useWithdrawHook() {
   const { checkUnauthorized } = useTokenCheck();
   const [isVerified, setVerified] = useState(false);
   const [loading, setLoading] = useState(false);
+  const { showToast } = useToast();
 
   useEffect(() => {
     checkUnauthorized();
@@ -15,9 +17,9 @@ export default function useWithdrawHook() {
     try {
       setLoading(true);
       await withdraw();
-      alert('회원 탈퇴 성공!');
+      showToast('회원 탈퇴 성공! ✌️');
     } catch (e: any) {
-      console.log(e);
+      showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
     } finally {
       setLoading(false);
     }

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -5,12 +5,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { login } from '@/apis/login';
 import { useUserStore } from '@/stores/userStore';
+import { useToast } from '@/app/ToastContext';
 
 type LoginFormData = z.infer<typeof loginSchema>;
 
 export default function useLoginForm() {
   const router = useRouter();
   const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const { showToast } = useToast();
 
   const loginForm = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -50,15 +52,13 @@ export default function useLoginForm() {
       router.push('/');
     } catch (e: any) {
       const errorCode = e?.response?.data?.error;
-      console.log(e);
       if (errorCode === 'invalid_password') {
         setError('password', {
           type: 'manual',
           message: '이메일 또는 비밀번호를 확인해 주세요.',
         });
       } else {
-        if (errorCode === undefined) alert(e);
-        else alert(errorCode);
+        showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
       }
     }
   };

--- a/kakaobase/src/hooks/user/usePasswordStep.tsx
+++ b/kakaobase/src/hooks/user/usePasswordStep.tsx
@@ -4,11 +4,13 @@ import { passwordConfirmSchema } from '@/schemas/passwordConfirmSchema';
 import { z } from 'zod';
 import changePassword from '@/apis/changePassword';
 import { useState } from 'react';
+import { useToast } from '@/app/ToastContext';
 
 export type PasswordFormData = z.infer<typeof passwordConfirmSchema>;
 
 export const usePasswordStep = () => {
   const [loading, setLoading] = useState(false);
+  const { showToast } = useToast();
   const methods = useForm<PasswordFormData>({
     resolver: zodResolver(passwordConfirmSchema),
     mode: 'all',
@@ -26,9 +28,9 @@ export const usePasswordStep = () => {
         email: email,
         password: methods.getValues('password'),
       });
-      alert('비밀번호 변경 완료');
+      showToast('비밀번호 변경 성공! ✌️');
     } catch (e: any) {
-      console.log(e);
+      showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
     } finally {
       setLoading(false);
     }

--- a/kakaobase/src/hooks/user/useSingupStep2.tsx
+++ b/kakaobase/src/hooks/user/useSingupStep2.tsx
@@ -1,4 +1,5 @@
 import signup from '@/apis/signup';
+import { useToast } from '@/app/ToastContext';
 import { courseMap } from '@/lib/courseMap';
 import { signupStep2Schema } from '@/schemas/signupStep2Schema';
 import { useSignupStore } from '@/stores/signupStore';
@@ -14,6 +15,7 @@ export const useSignupForm = () => {
   const step1Info = useSignupStore((state) => state.step1);
   const step2Info = useSignupStore((state) => state.step2);
   const setStep2Info = useSignupStore((state) => state.setStep2);
+  const { showToast } = useToast();
 
   const methods = useForm<SignupStep2Data>({
     resolver: zodResolver(signupStep2Schema),
@@ -45,12 +47,12 @@ export const useSignupForm = () => {
         github_url: step2Info.githubUrl,
       };
 
-      const response = await signup(request);
-      console.log(response);
+      await signup(request);
 
+      showToast('회원 가입 성공! ✌️');
       router.push('/login');
     } catch (e: any) {
-      console.log(e.response);
+      showToast('회원 가입 실패! 잠시 후 다시 시도해 주세요. 😭');
     }
   };
 

--- a/kakaobase/src/hooks/user/useTokenCheckHook.tsx
+++ b/kakaobase/src/hooks/user/useTokenCheckHook.tsx
@@ -1,9 +1,11 @@
 import { refreshToken } from '@/apis/login';
+import { useToast } from '@/app/ToastContext';
 import { getClientCookie } from '@/lib/getClientCookie';
 import { useRouter } from 'next/navigation';
 
 export default function useTokenCheck() {
   const router = useRouter();
+  const { showToast } = useToast();
   async function checkUnauthorized() {
     const accessToken = getClientCookie('accessToken');
     if (!accessToken) {
@@ -11,13 +13,15 @@ export default function useTokenCheck() {
         const response = await refreshToken();
         document.cookie = `accessToken=${response.data.access_token}; path=/; secure; samesite=lax; max-age=1800`; //30분
       } catch (e: any) {
-        console.log(e);
         if (
           e.response?.data.error === 'refresh_token_invalid' ||
           e.response?.data.error === 'refresh_token_missing'
         ) {
-          router.push('/login');
+          showToast('다시 로그인 해 주세요. 😊');
+        } else {
+          showToast('문제 발생! 다시 로그인 해 주세요. 😭');
         }
+        router.push('/login');
       }
     }
   }


### PR DESCRIPTION
## [FEAT] 토스트 구현
- ui
- 로직
- 프로필 링크 공유 복사 완료 메시지 테스트 완료
- 토스트 Context 생성
-> ToastContext.tsx 작성
-> providers에 적용
-> Toast 컴포넌트에서 useToast 불러오는 방식으로 로직 수정
-> 프로필 공유 링크 복사에도 수정하여 적용

## 삭제 시 토스트 출력
- 게시글/댓글/대댓글 삭제 시 토스트 출력

## 토스트 적용
- 게시글 상세 조회
- 게시글 업로드 시
- 프로필 이미지 저장 시
- 회원 탈퇴 시
- 로그인 시
- 비밀번호 변경 시
- 회원 가입 시
- 토큰 재발급 시
- 기타 오류 시 console -> 토스트 출력