### PR TITLE
[FEAT] 프로필 편집/탈퇴 로직 구현

### DIFF
--- a/kakaobase/src/apis/editProfile.tsx
+++ b/kakaobase/src/apis/editProfile.tsx
@@ -1,16 +1,39 @@
 import { getClientCookie } from '@/lib/getClientCookie';
 import api from './api';
 
-export default async function editProfile({ imageUrl }: { imageUrl: string }) {
+export async function editProfile({ imageUrl }: { imageUrl: string }) {
   const accessToken = getClientCookie('accessToken');
   try {
-    const response = await api.put('/users/images', {
-      image_url: imageUrl,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
+    await api.put(
+      '/users/images',
+      {
+        image_url: imageUrl,
       },
-    });
-    console.log(response);
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
+  }
+}
+
+export async function editGithub({ url }: { url: string }) {
+  const accessToken = getClientCookie('accessToken');
+  try {
+    await api.put(
+      '/users/github-url',
+      {
+        github_url: url,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
   } catch (e: unknown) {
     if (e instanceof Error) throw e;
   }

--- a/kakaobase/src/apis/login.tsx
+++ b/kakaobase/src/apis/login.tsx
@@ -11,7 +11,6 @@ interface LoginResponse {
     access_token: string;
     class_name: string;
     nickname: string;
-    image_url: string;
     member_id: string;
   };
 }

--- a/kakaobase/src/components/profile/QR/CopyUrl.tsx
+++ b/kakaobase/src/components/profile/QR/CopyUrl.tsx
@@ -7,7 +7,7 @@ export default function CopyUrl({ url }: { url: string }) {
     if (!url) return;
     try {
       await navigator.clipboard.writeText(url);
-      showToast('복사 완료!');
+      showToast('복사 완료! ✌️');
     } catch (err) {
       showToast('복사 실패 😭');
     }

--- a/kakaobase/src/components/profile/edit/ImageInput.tsx
+++ b/kakaobase/src/components/profile/edit/ImageInput.tsx
@@ -23,7 +23,6 @@ export default function ImageInput({
     const file = e.target.files?.[0];
     if (file) {
       setValue('imageFile', file, { shouldValidate: true });
-      const url = URL.createObjectURL(file);
       handleSubmit(onSubmit)();
     }
   }

--- a/kakaobase/src/components/profile/edit/TopArea.tsx
+++ b/kakaobase/src/components/profile/edit/TopArea.tsx
@@ -3,6 +3,8 @@
 import ReadOnlyUserInfo from './ReadOnlyUserInfo';
 import ImageInput from './ImageInput';
 import useImageEditHook from '@/hooks/profile/useImageEditHook';
+import { useUserStore } from '@/stores/userStore';
+import { courseMapReverse } from '@/lib/courseMap';
 
 export default function TopArea() {
   const {
@@ -13,6 +15,7 @@ export default function TopArea() {
     setValue,
     previewUrl,
   } = useImageEditHook();
+  const { name, nickname, course } = useUserStore();
 
   return (
     <div className="flex flex-col w-full">
@@ -28,8 +31,8 @@ export default function TopArea() {
           image={previewUrl}
         />
         <div className="flex flex-col gap-3">
-          <ReadOnlyUserInfo label="이름" value="daisy.kim(김도현)" />
-          <ReadOnlyUserInfo label="과정명" value="카카오테크 부트캠프 2기" />
+          <ReadOnlyUserInfo label="이름" value={`${nickname} / ${name}`} />
+          <ReadOnlyUserInfo label="과정명" value={courseMapReverse[course]} />
         </div>
       </div>
     </div>

--- a/kakaobase/src/components/profile/edit/Wrapper.tsx
+++ b/kakaobase/src/components/profile/edit/Wrapper.tsx
@@ -3,15 +3,33 @@ import SubmitButtonSmall from '@/components/common/button/SubmitButtonSmall';
 import UserInput from '@/components/inputs/UserInput';
 import RoutingButtons from './RoutingButtons';
 import TopArea from './TopArea';
+import useGithubEditHook from '@/hooks/profile/useGithubEditHook';
 
 export default function Wrapper() {
+  const {
+    githubUrl,
+    onSubmit,
+    register,
+    formState: { errors, isValid },
+    handleSubmit,
+  } = useGithubEditHook();
+
   return (
     <div className="flex justify-center items-center animate-slide-in flex-col">
       <div className="flex bg-containerColor px-8 py-10 rounded-xl flex flex-col items-center gap-8 max-w-sm">
         <TopArea />
         <div className="flex items-center gap-4 w-full">
-          <UserInput label="깃허브 링크" errorMessage="asdf" />
-          <SubmitButtonSmall label="저장" />
+          <UserInput
+            label="깃허브 링크"
+            placeholder={githubUrl}
+            {...register('githubUrl')}
+            errorMessage={errors.githubUrl?.message || ''}
+          />
+          <SubmitButtonSmall
+            label="저장"
+            disabled={!isValid}
+            onClick={handleSubmit(onSubmit)}
+          />
         </div>
         <RoutingButtons />
       </div>

--- a/kakaobase/src/hooks/auth/useEmailAuth.tsx
+++ b/kakaobase/src/hooks/auth/useEmailAuth.tsx
@@ -73,6 +73,7 @@ export const useEmailAuth = () => {
       setCodeValid(false);
       setCodeButtonLabel('완료');
       timer.stop();
+      showToast('이메일 인증 성공! ✌️');
     } catch (e: any) {
       if (e.response.data.error === 'email_code_invalid') {
         incrementAttempt();

--- a/kakaobase/src/hooks/profile/useGithubEditHook.tsx
+++ b/kakaobase/src/hooks/profile/useGithubEditHook.tsx
@@ -1,0 +1,44 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import useTokenCheck from '../user/useTokenCheckHook';
+import { useState } from 'react';
+import { useToast } from '@/app/ToastContext';
+import { useUserStore } from '@/stores/userStore';
+import { githubSchema } from '@/schemas/githubSchema';
+import { editGithub } from '@/apis/editProfile';
+
+export type githubData = z.infer<typeof githubSchema>;
+
+export default function useGithubEditHook() {
+  const { checkUnauthorized } = useTokenCheck();
+  const [loading, setLoading] = useState(false);
+  const { showToast } = useToast();
+  const { githubUrl, setUserInfo } = useUserStore();
+
+  const methods = useForm<githubData>({
+    resolver: zodResolver(githubSchema),
+    mode: 'all',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      githubUrl,
+    },
+  });
+
+  const onSubmit = async (data: githubData) => {
+    checkUnauthorized();
+    try {
+      setLoading(true);
+      const response = await editGithub({ url: data.githubUrl });
+      console.log(response);
+      setUserInfo({ githubUrl: data.githubUrl });
+      showToast('깃허브 링크 변경 완료! ✌️');
+    } catch (e: any) {
+      showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { onSubmit, loading, ...methods, githubUrl };
+}

--- a/kakaobase/src/hooks/profile/useWithdrawHook.tsx
+++ b/kakaobase/src/hooks/profile/useWithdrawHook.tsx
@@ -2,12 +2,14 @@ import withdraw from '@/apis/withdraw';
 import { useEffect, useState } from 'react';
 import useTokenCheck from '../user/useTokenCheckHook';
 import { useToast } from '@/app/ToastContext';
+import { useRouter } from 'next/navigation';
 
 export default function useWithdrawHook() {
   const { checkUnauthorized } = useTokenCheck();
   const [isVerified, setVerified] = useState(false);
   const [loading, setLoading] = useState(false);
   const { showToast } = useToast();
+  const router = useRouter();
 
   useEffect(() => {
     checkUnauthorized();
@@ -18,6 +20,7 @@ export default function useWithdrawHook() {
       setLoading(true);
       await withdraw();
       showToast('회원 탈퇴 성공! ✌️');
+      router.push('/login');
     } catch (e: any) {
       showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
     } finally {

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -35,18 +35,11 @@ export default function useLoginForm() {
       const response = await login(requestBody);
       document.cookie = `accessToken=${response.data.access_token}; path=/; secure; samesite=lax; max-age=1800`; //30분
       localStorage.setItem('myCourse', response.data.class_name);
-      localStorage.setItem('nickname', response.data.nickname);
-      localStorage.setItem('profile', response.data.image_url);
-      localStorage.setItem('userId', response.data.member_id);
 
-      if (autoLogin) {
-        localStorage.setItem('autoLogin', 'true');
-      } else {
-        localStorage.setItem('autoLogin', 'false');
-      }
       setUserInfo({
         course: response.data.class_name,
         nickname: response.data.nickname,
+        userId: Number(response.data.member_id),
         autoLogin: autoLogin,
       });
       router.push('/');

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -57,6 +57,8 @@ export default function useLoginForm() {
           type: 'manual',
           message: '이메일 또는 비밀번호를 확인해 주세요.',
         });
+      } else if (errorCode === 'resource_not_found') {
+        setError('email', { message: '가입되지 않은 이메일입니다.' });
       } else {
         showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
       }

--- a/kakaobase/src/schemas/githubSchema.tsx
+++ b/kakaobase/src/schemas/githubSchema.tsx
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const githubSchema = z.object({
+  githubUrl: z
+    .string()
+    .min(1, { message: '*자신의 깃허브 프로필 url을 입력해 주세요.' })
+    .startsWith('https://github.com/', {
+      message: '*깃허브 url 형식이 올바르지 않습니다.',
+    }),
+});

--- a/kakaobase/src/schemas/signupStep2Schema.tsx
+++ b/kakaobase/src/schemas/signupStep2Schema.tsx
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { githubSchema } from './githubSchema';
 
 export const courseEnum = z.enum([
   '클라우드 네이티브 제주 1기',
@@ -26,10 +27,5 @@ export const signupStep2Schema = z.object({
     courseEnum,
     { message: '수강 과정을 선택해 주세요.' }
   ),
-  githubUrl: z
-    .string()
-    .min(1, { message: '*자신의 깃허브 프로필 url을 입력해 주세요.' })
-    .startsWith('https://github.com/', {
-      message: '*깃허브 url 형식이 올바르지 않습니다.',
-    }),
+  githubUrl: githubSchema,
 });


### PR DESCRIPTION
## 토스트 메시지 수정
- 이모지 추가

## 깃허브 링크 수정 로직
- 깃허브 링크 수정 api
- 프로필 이미지 수정 api 인증 param 위치 수정 (잘못된 곳에 넣고 있었음)
- 깃허브 링크 schema 작성
- 회원 가입 2단계에서도 githubSchema 적용
- 깃허브 수정용 커스텀 훅 작성
- UserInput, 제출 버튼 컴포넌트에 적용

## 로그인/탈퇴 로직 수정
- 가입되지 않은 경우 이메일에 에러 표시
- 로그인 시 프로필 이미지 반환 없음 -> 제거
- 로그인 시 localStorage 삭제 - 전역 상태 관리 사용으로 바꾸기
- 탈퇴 시 로그인 페이지로 이동

## 프로필 편집 페이지 수정
- 이름, 닉네임, 과정 - zustand에서 가져오기 (전역으로 관리하도록 변경)
- 프로필 이미지 - zustand로 수정 및 불필요한 출력 메시지 삭제