### PR TITLE
[FEAT] 팔로우, 팔로워 목록 조회, 팔로우 요청/취소 로직 구현

### DIFF
--- a/kakaobase/src/apis/follow.tsx
+++ b/kakaobase/src/apis/follow.tsx
@@ -1,3 +1,4 @@
+import { getClientCookie } from '@/lib/getClientCookie';
 import api from './api';
 
 //팔로우 요청 api
@@ -30,13 +31,18 @@ export async function getFollowers({
 }: {
   userId: number;
   limit: number;
-  cursor: number;
+  cursor?: number;
 }) {
+  const params: Record<string, any> = { limit };
+  if (cursor !== undefined) params.cursor = cursor;
   try {
-    const response = await api.get(
-      `/users/${userId}/followers?limit=${limit}&cursor=${cursor}`
-    );
-    return response.data;
+    const response = await api.get(`/users/${userId}/followers`, {
+      params,
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
+    return response.data.data;
   } catch (e: unknown) {
     if (e instanceof Error) throw e;
   }
@@ -50,13 +56,18 @@ export async function getFollowings({
 }: {
   userId: number;
   limit: number;
-  cursor: number;
+  cursor?: number;
 }) {
+  const params: Record<string, any> = { limit };
+  if (cursor !== undefined) params.cursor = cursor;
   try {
-    const response = await api.get(
-      `/users/${userId}/followings?limit=${limit}&cursor=${cursor}`
-    );
-    return response.data;
+    const response = await api.get(`/users/${userId}/followings`, {
+      params,
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
+    return response.data.data;
   } catch (e: unknown) {
     if (e instanceof Error) throw e;
   }

--- a/kakaobase/src/apis/follow.tsx
+++ b/kakaobase/src/apis/follow.tsx
@@ -4,22 +4,30 @@ import api from './api';
 //팔로우 요청 api
 export async function postFollow({ id }: { id: number }) {
   try {
-    const response = await api.post(`/users/${id}/follows`);
-    console.log(response.data);
-    return response.data;
-  } catch (e) {
-    console.log(e);
+    await api.post(
+      `/users/${id}/follows`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${getClientCookie('accessToken')}`,
+        },
+      }
+    );
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
   }
 }
 
 //팔로우 취소 api
 export async function deleteFollow({ id }: { id: number }) {
   try {
-    const response = await api.delete(`/users/${id}/follows`);
-    console.log(response.data);
-    return response.data;
-  } catch (e) {
-    console.log(e);
+    await api.delete(`/users/${id}/follows`, {
+      headers: {
+        Authorization: `Bearer ${getClientCookie('accessToken')}`,
+      },
+    });
+  } catch (e: unknown) {
+    if (e instanceof Error) throw e;
   }
 }
 

--- a/kakaobase/src/app/profile/[userId]/followings/page.tsx
+++ b/kakaobase/src/app/profile/[userId]/followings/page.tsx
@@ -1,12 +1,12 @@
 import Header from '@/components/common/header/Header';
 import NavBar from '@/components/common/NavBar';
-import UserList from '@/components/likeFollow/UserList';
+import UserFollowList from '@/components/social/UserFollowList';
 
 export default function Page({ params }: { params: { userId: number } }) {
   return (
     <div className="flex flex-col h-screen">
       <Header label="팔로잉 목록" />
-      <UserList userId={params.userId} />
+      <UserFollowList userId={params.userId} />
       <NavBar />
     </div>
   );

--- a/kakaobase/src/app/providers.tsx
+++ b/kakaobase/src/app/providers.tsx
@@ -7,7 +7,7 @@ import Toast from '@/components/common/Toast';
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 5,
+      staleTime: 1000 * 60 * 0,
       gcTime: 1000 * 60 * 30,
     },
   },

--- a/kakaobase/src/components/common/NavBar.tsx
+++ b/kakaobase/src/components/common/NavBar.tsx
@@ -12,6 +12,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import { getClientCookie } from '@/lib/getClientCookie';
 import { useEffect, useState } from 'react';
+import { useUserStore } from '@/stores/userStore';
 
 function NavItem({ icon: Icon, path }: { icon: LucideIcon; path?: string }) {
   const pathName = usePathname();
@@ -33,29 +34,21 @@ function NavItem({ icon: Icon, path }: { icon: LucideIcon; path?: string }) {
 }
 
 function LoginProfile({ path }: { path: string }) {
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [userId, setUserId] = useState('');
   const pathName = usePathname();
   const router = useRouter();
+  const { userId, profileImageUrl } = useUserStore();
 
   const isActive = pathName.includes(path);
-
-  useEffect(() => {
-    const url = localStorage.getItem('profile') || '';
-    setImageUrl(url);
-    const id = localStorage.getItem('userId') || '';
-    setUserId(id);
-  }, []);
 
   function navMyProfile() {
     router.push(`/profile/${userId}`);
   }
 
-  if (imageUrl === null) return null; // hydration mismatch 방지
+  if (profileImageUrl === null) return null; // hydration mismatch 방지
 
   return (
     <div className="flex" onClick={navMyProfile}>
-      {imageUrl === '' || imageUrl === 'null' ? (
+      {profileImageUrl === '' || profileImageUrl === 'null' ? (
         <User
           className={clsx(
             'w-6 h-6 transition-colors cursor-pointer',
@@ -64,7 +57,7 @@ function LoginProfile({ path }: { path: string }) {
         />
       ) : (
         <Image
-          src={imageUrl}
+          src={profileImageUrl}
           width={12}
           height={12}
           alt="profile"

--- a/kakaobase/src/components/post/CountsInfo.tsx
+++ b/kakaobase/src/components/post/CountsInfo.tsx
@@ -59,6 +59,10 @@ export default function CountsInfo({ post }: { post: PostEntity }) {
 
   const router = useRouter();
   function navLikeList(e: React.MouseEvent<HTMLElement>) {
+    if (post.type === 'post') {
+      sessionStorage.setItem('scrollToPostId', String(post.id));
+      sessionStorage.setItem('scrollPosition', String(window.scrollY));
+    }
     e.stopPropagation();
     router.push(`/likes/${post.type}/${post.id}`);
   }

--- a/kakaobase/src/components/post/UserInfo.tsx
+++ b/kakaobase/src/components/post/UserInfo.tsx
@@ -73,9 +73,9 @@ export function UserInfo({ post }: { post: PostEntity }) {
         >
           {post.nickname}
         </div>
-        {/* {post.isMine ? null : (
-          <FollowButtonSmall isFollowing={post.isFollowing} />
-        )} */}
+        {post.isMine ? null : (
+          <FollowButtonSmall isFollowing={post.isFollowing} id={post.userId} />
+        )}
       </div>
       <div
         className="flex gap-2 align-center justify-center flex-shrink-0"

--- a/kakaobase/src/components/user/FollowButtonSmall.tsx
+++ b/kakaobase/src/components/user/FollowButtonSmall.tsx
@@ -2,21 +2,23 @@ import { useFollowToggle } from '@/hooks/user/useFollowHook';
 
 export default function FollowButtonSmall({
   isFollowing,
+  id,
 }: {
   isFollowing: boolean;
+  id: number;
 }) {
-  const { following, toggleFollow } = useFollowToggle(isFollowing);
+  const { following, toggleFollow } = useFollowToggle(isFollowing, id);
   return (
     <button
       onClick={toggleFollow}
       className={`h-4 px-2 min-w-fit align-center rounded-full flex justify-center ${
-        !following
+        following
           ? 'bg-myLightBlue text-textOnLight'
           : 'bg-myBlue text-textOnBlue'
       }`}
     >
       <div className="flex justify-self-center text-[0.625rem]">
-        {following ? '팔로우' : '언팔로우'}
+        {following ? '언팔로우' : '팔로우'}
       </div>
     </button>
   );

--- a/kakaobase/src/hooks/social/useFollowListHook.tsx
+++ b/kakaobase/src/hooks/social/useFollowListHook.tsx
@@ -1,0 +1,38 @@
+import { getFollowers, getFollowings } from '@/apis/follow';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { usePathname } from 'next/navigation';
+
+export default function useFollowListHook({ userId }: { userId: number }) {
+  const path = usePathname();
+  //팔로워 목록
+  if (path.includes('follwers')) {
+    return useInfiniteQuery({
+      queryKey: ['followers', userId],
+      queryFn: async ({ pageParam }: { pageParam?: number }) => {
+        const response = await getFollowings({
+          userId: userId,
+          limit: 30,
+          cursor: pageParam,
+        });
+        return response;
+      },
+      getNextPageParam: (lastPage) => lastPage.at(-1),
+      initialPageParam: undefined,
+    });
+  } else {
+    //팔로잉 목록
+    return useInfiniteQuery({
+      queryKey: ['followings', userId],
+      queryFn: async ({ pageParam }: { pageParam?: number }) => {
+        const response = await getFollowers({
+          userId: userId,
+          limit: 30,
+          cursor: pageParam,
+        });
+        return response;
+      },
+      getNextPageParam: (lastPage) => lastPage.at(-1),
+      initialPageParam: undefined,
+    });
+  }
+}

--- a/kakaobase/src/hooks/user/useFollowHook.tsx
+++ b/kakaobase/src/hooks/user/useFollowHook.tsx
@@ -1,18 +1,24 @@
+import { deleteFollow, postFollow } from '@/apis/follow';
+import { useToast } from '@/app/ToastContext';
 import { useState } from 'react';
 
-export function useFollowToggle(initial: boolean) {
+export function useFollowToggle(initial: boolean, id: number) {
   const [following, setFollowing] = useState(initial);
+  const { showToast } = useToast();
 
   const toggleFollow = async () => {
     try {
       if (following) {
-        // 언팔로우 API 호출
+        await deleteFollow({ id });
+        showToast('언팔로우 성공! ✌️');
       } else {
-        // 팔로우 API 호출
+        postFollow({ id });
+        showToast('팔로우 성공! ✌️');
       }
       setFollowing(!following);
     } catch (e) {
-      console.error('팔로우 토글 실패', e);
+      if (following) showToast('언팔로우 실패 😭');
+      else showToast('팔로우 실패 😭');
     }
   };
 

--- a/kakaobase/src/lib/mapPost.tsx
+++ b/kakaobase/src/lib/mapPost.tsx
@@ -17,7 +17,7 @@ export function mapToPostEntity(post: any, type: PostType): PostEntity {
     content: post.content ?? '',
     likeCount: post.like_count,
     isLiked: post.is_liked,
-    isFollowing: post.user.is_following,
+    isFollowing: post.user.is_followed,
     createdAt: post.created_at,
   };
 


### PR DESCRIPTION
## 팔로잉, 팔로워 목록 조회
- api 수정
- 폴더 변경에 따른 의존성 변경
- react-query 반영
- CountsInfo 좋아요 목록 조회 이후 뒤로 가기 시 스크롤 유지

## 코드 수정
- staleTime 0초로 수정
- userId 저장 방식 변경 : localStorage -> 전역 상태로 저장

## 팔로우 로직 구현
- 서버 응답 is_following이 아닌 is_followed 였음 -> 매핑 수정
- 팔로우 요청/취소 훅에 api 반영
- 팔로우 버튼이 반대로 출력되고 있어서 수정 (FollowButtonSmall)
- 팔로우 버튼 활성화 및 id 추가
- 팔로우 api에 인증 요소 추가