### PR TITLE
[FIX] 댓글에서 post id 추적

### DIFF
--- a/kakaobase/src/apis/commentList.tsx
+++ b/kakaobase/src/apis/commentList.tsx
@@ -23,7 +23,6 @@ export default async function getComments(
       },
     });
 
-    console.log(response.data.data);
     return response.data.data.comments.map((p: any) =>
       mapToPostEntity(p, 'comment')
     );

--- a/kakaobase/src/components/post/PostCard.tsx
+++ b/kakaobase/src/components/post/PostCard.tsx
@@ -2,27 +2,27 @@
 import Image from 'next/image';
 import CountsInfo from './CountsInfo';
 import { UserProfile, UserInfo } from './UserInfo';
-import { useParams, usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { extractYoutubeVideoId } from '@/lib/formatYoutube';
-import { PostEntity } from '@/stores/postType';
+import { Comment, PostEntity } from '@/stores/postType';
 import clsx from 'clsx';
 import summaryCondition from '@/lib/summaryCondition';
 import Linkify from 'react-linkify';
 
 export default function PostCard({ post }: { post: PostEntity }) {
   const router = useRouter();
-  const params = useParams();
-
-  const postId = Number(params.postId);
-
   const path = usePathname();
+
+  function isComment(post: PostEntity): post is Comment {
+    return post.type === 'comment';
+  }
   function navDetail() {
     if (post.type === 'post') {
       sessionStorage.setItem('scrollToPostId', String(post.id));
       sessionStorage.setItem('scrollPosition', String(window.scrollY));
       router.push(`/post/${post.id}`);
-    } else if (post.type === 'comment') {
-      router.push(`/post/${postId}/comment/${post.id}`);
+    } else if (isComment(post)) {
+      router.push(`/post/${post.postId}/comment/${post.id}`);
     }
   }
   return (

--- a/kakaobase/src/lib/mapPost.tsx
+++ b/kakaobase/src/lib/mapPost.tsx
@@ -35,6 +35,7 @@ export function mapToPostEntity(post: any, type: PostType): PostEntity {
     return {
       ...base,
       commentCount: post.recomment_count,
+      postId: post.post_id,
     } as Comment;
   }
 

--- a/kakaobase/src/stores/postType.tsx
+++ b/kakaobase/src/stores/postType.tsx
@@ -23,6 +23,7 @@ export interface Post extends BasePost {
 
 export interface Comment extends BasePost {
   commentCount: number;
+  postId: number;
 }
 
 export interface Recomment extends BasePost {}


### PR DESCRIPTION
- 마이페이지에서 댓글 클릭 시 제대로 된 경로로 라우팅되지 않는 문제 해결
- 댓글 엔티티에 postId 추가 및 post_id 연결