### PR TITLE
[REFACTOR] localStorage 제거

### DIFF
--- a/kakaobase/src/apis/login.tsx
+++ b/kakaobase/src/apis/login.tsx
@@ -1,3 +1,4 @@
+import { Course } from '@/lib/Course';
 import api from './api';
 
 interface LoginRequest {
@@ -8,7 +9,7 @@ interface LoginRequest {
 interface LoginResponse {
   message: string;
   data: {
-    class_name: string;
+    class_name: Course;
     nickname: string;
     member_id: string;
     image_url: string;

--- a/kakaobase/src/apis/post.tsx
+++ b/kakaobase/src/apis/post.tsx
@@ -1,8 +1,8 @@
-import { PostType } from '@/lib/postType';
+import { Course } from '@/lib/Course';
 import api from './api';
 
 interface postParams {
-  postType: PostType;
+  postType: Course;
   id?: number;
 }
 

--- a/kakaobase/src/components/common/NavBar.tsx
+++ b/kakaobase/src/components/common/NavBar.tsx
@@ -34,8 +34,7 @@ function NavItem({ icon: Icon, path }: { icon: LucideIcon; path?: string }) {
 function LoginProfile({ path }: { path: string }) {
   const pathName = usePathname();
   const router = useRouter();
-  const { userId, profileImageUrl } = useUserStore();
-
+  const { userId, imageUrl } = useUserStore();
   const isActive = pathName.includes(path);
 
   function navMyProfile() {
@@ -44,7 +43,7 @@ function LoginProfile({ path }: { path: string }) {
 
   return (
     <div className="flex" onClick={navMyProfile}>
-      {profileImageUrl === '' || profileImageUrl === null ? (
+      {imageUrl === '' || imageUrl === null ? (
         <User
           className={clsx(
             'w-6 h-6 transition-colors cursor-pointer',
@@ -53,7 +52,7 @@ function LoginProfile({ path }: { path: string }) {
         />
       ) : (
         <Image
-          src={profileImageUrl}
+          src={imageUrl}
           width={12}
           height={12}
           alt="profile"

--- a/kakaobase/src/components/post/PostCourseSelector.tsx
+++ b/kakaobase/src/components/post/PostCourseSelector.tsx
@@ -1,31 +1,21 @@
 'use client';
 
 import useCourseSelectHook from '@/hooks/post/useCourseSelectHook';
-import { useEffect, useState } from 'react';
 
 export default function PostCourseSelector() {
-  const { course, myCourseLabel, handleChange } = useCourseSelectHook();
-  const [myCourse, setMyCourse] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setMyCourse(localStorage.getItem('myCourse'));
-    }
-  }, []);
+  const { course, selectedCourse, handleCurrentCourse, courseLabel } =
+    useCourseSelectHook();
 
   return (
     <div className="border-b-[1px] border-textOpacity50 shadow-sm px-6 py-6 mt-20 bg-bgColor text-textColor">
       <select
         name="post-course"
         className="bg-transparent focus:outline-none font-bold"
-        value={course}
-        onChange={handleChange}
-        defaultValue={course}
+        value={selectedCourse}
+        onChange={handleCurrentCourse}
       >
-        <option value="ALL">전체</option>
-        {myCourse !== 'ALL' && (
-          <option value={myCourse || 'ALL'}>{myCourseLabel}</option>
-        )}
+        <option value="ALL">자유</option>
+        {course !== 'ALL' && <option value={course}>{courseLabel}</option>}
       </select>
     </div>
   );

--- a/kakaobase/src/components/post/PostEditor.tsx
+++ b/kakaobase/src/components/post/PostEditor.tsx
@@ -11,6 +11,7 @@ import {
   UseFormSetValue,
   UseFormWatch,
 } from 'react-hook-form';
+import { useUserStore } from '@/stores/userStore';
 
 function HelperText({ errorMessage }: { errorMessage: string }) {
   return <div className="text-redHeart text-xs h-4">{errorMessage}</div>;
@@ -23,14 +24,7 @@ function ContentInput({
   register: UseFormRegister<NewPostData>;
   errors: FieldErrors<NewPostData>;
 }) {
-  const [nickname, setNickname] = useState<string | null>(null);
-
-  useEffect(() => {
-    const nick = localStorage.getItem('nickname') || '';
-    setNickname(nick);
-  }, []);
-
-  if (nickname === null) return null;
+  const { nickname } = useUserStore();
 
   return (
     <div className="w-full">

--- a/kakaobase/src/components/profile/Wrapper.tsx
+++ b/kakaobase/src/components/profile/Wrapper.tsx
@@ -12,7 +12,7 @@ import { useState } from 'react';
 import ListRouter from './ListRouter';
 
 export default function Wrapper({ userId }: { userId: number }) {
-  const { data, isLoading, handleModal, navEdit, isOpen } = useUserInfoHook({
+  const { data, isPending, handleModal, navEdit, isOpen } = useUserInfoHook({
     userId,
   });
   const { following, toggleFollow } = useFollowToggle(
@@ -21,7 +21,7 @@ export default function Wrapper({ userId }: { userId: number }) {
   );
   const [type, setType] = useState<profileListType>('게시글');
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <div className="flex mt-20 justify-center">
         <Loading />

--- a/kakaobase/src/hooks/post/list/usePostList.tsx
+++ b/kakaobase/src/hooks/post/list/usePostList.tsx
@@ -6,13 +6,13 @@ import {
   UseInfiniteQueryResult,
 } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import useCourseSelectHook from '../useCourseSelectHook';
+import { useUserStore } from '@/stores/userStore';
 
 export default function usePostList(): UseInfiniteQueryResult<
   InfiniteData<PostEntity[]>,
   Error
 > {
-  const { course } = useCourseSelectHook();
+  const { selectedCourse } = useUserStore();
 
   useEffect(() => {
     const targetId = sessionStorage.getItem('scrollToPostId');
@@ -28,12 +28,12 @@ export default function usePostList(): UseInfiniteQueryResult<
   }, []);
 
   return useInfiniteQuery({
-    queryKey: ['posts', course],
+    queryKey: ['posts', selectedCourse],
     queryFn: async ({ pageParam }: { pageParam?: number }) => {
       const response = await getPosts({
         limit: 6,
         cursor: pageParam,
-        course: course,
+        course: selectedCourse,
       });
       return response;
     },

--- a/kakaobase/src/hooks/post/useCourseSelectHook.tsx
+++ b/kakaobase/src/hooks/post/useCourseSelectHook.tsx
@@ -1,44 +1,22 @@
+import { Course } from '@/lib/Course';
 import { courseMapReverse } from '@/lib/courseMap';
-import { useEffect, useState } from 'react';
+import { useUserStore } from '@/stores/userStore';
 
 export default function useCourseSelectHook() {
-  const [course, setCourse] = useState<string>(() => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('currCourse') || 'ALL';
-    }
-    return 'ALL';
-  });
-  const [myCourseLabel, setMyCourseLabel] = useState('전체');
+  const { course, selectedCourse, setUserInfo } = useUserStore();
+  const courseLabel = course === 'ALL' ? '자유' : courseMapReverse[course];
 
-  useEffect(() => {
-    const curr = localStorage.getItem('currCourse');
-    const myCourse = localStorage.getItem('myCourse');
-
-    if (curr) setCourse(curr);
-
-    if (myCourse) {
-      setMyCourseLabel(courseMapReverse[myCourse]); //한국어로 매핑
-    } else {
-      setMyCourseLabel('전체');
-    }
-  }, []);
-
-  useEffect(() => {
-    const syncCourse = () => {
-      const curr = localStorage.getItem('currCourse');
-      setCourse(curr || 'ALL');
-    };
-
-    window.addEventListener('currCourseChange', syncCourse);
-    return () => window.removeEventListener('currCourseChange', syncCourse);
-  }, []);
-
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newCourse = e.target.value;
-    localStorage.setItem('currCourse', newCourse);
-    window.dispatchEvent(new Event('currCourseChange'));
-    setCourse(newCourse);
+  const handleCurrentCourse = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCourse = e.target.value as Course;
+    setUserInfo({
+      selectedCourse: newCourse,
+    });
   };
 
-  return { myCourseLabel, handleChange, course };
+  return {
+    courseLabel,
+    course,
+    selectedCourse,
+    handleCurrentCourse,
+  };
 }

--- a/kakaobase/src/hooks/post/useDeleteHook.tsx
+++ b/kakaobase/src/hooks/post/useDeleteHook.tsx
@@ -3,7 +3,7 @@ import { deletePost } from '@/apis/post';
 import { deleteRecomment } from '@/apis/recomment';
 import { queryClient } from '@/app/providers';
 import { useToast } from '@/app/ToastContext';
-import { PostType } from '@/lib/postType';
+import { useUserStore } from '@/stores/userStore';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -12,14 +12,11 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
   const path = usePathname();
   const [isOpened, setOpen] = useState(false);
   const { showToast } = useToast();
+  const { selectedCourse } = useUserStore();
   async function deletePostExecute() {
-    const postType =
-      typeof window !== 'undefined'
-        ? (localStorage.getItem('currCourse') as PostType) || 'ALL'
-        : 'ALL';
     try {
       if (type === 'post') {
-        await deletePost({ postType, id });
+        await deletePost({ postType: selectedCourse, id });
         queryClient.invalidateQueries({ queryKey: ['posts'] });
       } else if (type === 'comment') {
         await deleteComment({ id });
@@ -38,6 +35,7 @@ export function useDeleteHook({ id, type }: { id: number; type: string }) {
       showToast('문제 발생! 잠시 후 다시 시도해 주세요. 😭');
     }
   }
+
   function closeModal() {
     setOpen(false);
   }

--- a/kakaobase/src/hooks/post/usePostDetailHook.tsx
+++ b/kakaobase/src/hooks/post/usePostDetailHook.tsx
@@ -1,25 +1,22 @@
 import { useEffect, useState } from 'react';
 import { getPost } from '@/apis/post';
-import { PostType } from '@/lib/postType';
 import { mapToPostEntity } from '@/lib/mapPost';
 import { usePathname, useRouter } from 'next/navigation';
 import { getComment } from '@/apis/comment';
 import { PostEntity } from '@/stores/postType';
 import { useToast } from '@/app/ToastContext';
+import { useUserStore } from '@/stores/userStore';
 
 export default function usePostDetail({ id }: { id: number }) {
   const [post, setPost] = useState<PostEntity>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const { selectedCourse } = useUserStore();
   const { showToast } = useToast();
   const path = usePathname();
   const router = useRouter();
 
   const fetchPost = async () => {
-    const postType =
-      typeof window !== 'undefined'
-        ? (localStorage.getItem('currCourse') as PostType) || 'ALL'
-        : 'ALL';
     let response = [];
     try {
       setLoading(true);
@@ -27,7 +24,7 @@ export default function usePostDetail({ id }: { id: number }) {
         response = await getComment({ id });
         setPost(mapToPostEntity(response.data.data, 'comment'));
       } else {
-        response = await getPost({ postType, id });
+        response = await getPost({ postType: selectedCourse, id });
         setPost(mapToPostEntity(response, 'post'));
       }
     } catch (e: any) {

--- a/kakaobase/src/hooks/post/usePostEditorForm.tsx
+++ b/kakaobase/src/hooks/post/usePostEditorForm.tsx
@@ -1,7 +1,7 @@
 import postToS3 from '@/apis/imageS3';
 import { postPost } from '@/apis/post';
 import { queryClient } from '@/app/providers';
-import { PostType } from '@/lib/postType';
+import { Course } from '@/lib/Course';
 import { postSchema } from '@/schemas/postSchema';
 import { usePostStore } from '@/stores/postStore';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { useToast } from '@/app/ToastContext';
+import { useUserStore } from '@/stores/userStore';
 
 export type NewPostData = z.infer<typeof postSchema>;
 
@@ -20,6 +21,7 @@ export const usePostEditorForm = () => {
   const imageUrl = usePostStore((state) => state.imageUrl);
   const { showToast } = useToast();
   const [isLoading, setLoading] = useState(false);
+  const { selectedCourse } = useUserStore();
 
   const methods = useForm<NewPostData>({
     resolver: zodResolver(postSchema),
@@ -33,9 +35,6 @@ export const usePostEditorForm = () => {
   });
 
   const onSubmit = async (data: NewPostData) => {
-    let postType = localStorage.getItem('currCourse') as PostType;
-    if (!postType) postType = 'ALL';
-
     try {
       setLoading(true);
       let imageUrl = '';
@@ -44,7 +43,7 @@ export const usePostEditorForm = () => {
       }
 
       await postPost(
-        { postType },
+        { postType: selectedCourse },
         {
           content: data.content,
           image_url: imageUrl,

--- a/kakaobase/src/hooks/profile/useImageEditHook.tsx
+++ b/kakaobase/src/hooks/profile/useImageEditHook.tsx
@@ -12,12 +12,12 @@ export type imageData = z.infer<typeof profileImageSchema>;
 
 export default function useImageEditHook() {
   const [loading, setLoading] = useState(false);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const { imageUrl, setUserInfo } = useUserStore();
+  const [previewUrl, setPreviewUrl] = useState<string>(imageUrl);
   const { showToast } = useToast();
-  const { profileImageUrl, setUserInfo } = useUserStore();
 
   useEffect(() => {
-    setPreviewUrl(profileImageUrl);
+    setPreviewUrl(imageUrl);
   }, []);
 
   const methods = useForm<imageData>({
@@ -37,7 +37,7 @@ export default function useImageEditHook() {
         imageUrl = await postToS3(data.imageFile, 'profile_image');
       }
       setPreviewUrl(imageUrl);
-      setUserInfo({ profileImageUrl: imageUrl });
+      setUserInfo({ imageUrl: imageUrl });
 
       await editProfile({ imageUrl });
       showToast('프로필 이미지 저장 완료! ✌️');

--- a/kakaobase/src/hooks/user/useLoginForm.tsx
+++ b/kakaobase/src/hooks/user/useLoginForm.tsx
@@ -11,7 +11,7 @@ type LoginFormData = z.infer<typeof loginSchema>;
 
 export default function useLoginForm() {
   const router = useRouter();
-  const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const { setUserInfo } = useUserStore();
   const { showToast } = useToast();
 
   const loginForm = useForm<LoginFormData>({
@@ -33,13 +33,13 @@ export default function useLoginForm() {
 
     try {
       const response = await login(requestBody);
-      localStorage.setItem('myCourse', response.data.class_name);
 
       setUserInfo({
         course: response.data.class_name,
+        selectedCourse: response.data.class_name,
         nickname: response.data.nickname,
         userId: Number(response.data.member_id),
-        profileImageUrl: response.data.image_url,
+        imageUrl: response.data.image_url,
       });
       router.push('/');
     } catch (e: any) {

--- a/kakaobase/src/lib/Course.tsx
+++ b/kakaobase/src/lib/Course.tsx
@@ -1,0 +1,1 @@
+export type Course = 'ALL' | 'PANGYO_1' | 'JEJU_1' | 'PANGYO_2' | 'JEJU_2';

--- a/kakaobase/src/lib/postType.tsx
+++ b/kakaobase/src/lib/postType.tsx
@@ -1,1 +1,0 @@
-export type PostType = 'ALL' | 'PANGYO_1' | 'JEJU_1' | 'PANGYO_2' | 'JEJU_2';

--- a/kakaobase/src/stores/userStore.tsx
+++ b/kakaobase/src/stores/userStore.tsx
@@ -1,14 +1,15 @@
+import { Course } from '@/lib/Course';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
 export interface UserState {
   userId: number;
-  email: string;
   name: string;
   nickname: string;
-  course: string;
+  course: Course;
+  selectedCourse: Course;
   githubUrl: string;
-  profileImageUrl: string;
+  imageUrl: string;
   setUserInfo: (user: Partial<UserState>) => void;
   reset: () => void;
 }
@@ -16,28 +17,36 @@ export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       userId: 0,
-      email: '',
       name: '',
       nickname: '',
-      course: '',
+      course: 'ALL',
+      selectedCourse: 'ALL',
       githubUrl: '',
-      profileImageUrl: '',
+      imageUrl: '',
       setUserInfo: (user) => set((state) => ({ ...state, ...user })),
       reset: () =>
         set({
           userId: 0,
-          email: '',
           name: '',
           nickname: '',
-          course: '',
+          course: 'ALL',
+          selectedCourse: 'ALL',
           githubUrl: '',
-          profileImageUrl: '',
+          imageUrl: '',
         }),
     }),
     {
-      name: 'user-storage', // localStorage key
+      name: 'user-storage',
       storage: createJSONStorage(() => localStorage),
-      // whitelist: ['userId','email',…],  // 선택적으로 저장할 필드 지정 가능
+      partialize: (state) => ({
+        userId: state.userId,
+        name: state.name,
+        nickname: state.nickname,
+        course: state.course,
+        selectedCourse: state.selectedCourse,
+        githubUrl: state.githubUrl,
+        imageUrl: state.imageUrl,
+      }),
     }
   )
 );


### PR DESCRIPTION
- 사용자 개인 정보를 받을 수 있는 방법이 없어 부득이하게 전역상태를 localStorage에 넣고 있음
- 로그인 시, 사용자가 상단 게시글 유형(course) 변경 시 localStorage 안 쓰게 함
- 이외 localStorage 코드 전부 제거
- course 로직 수정
- 게시글 작성, 삭제 시 postType 테스트 완료
- 전역 상태 : profileImageUrl -> imageUrl
- postType 파일명 변경 : postType -> Course