### PR TITLE
[HOTFIX] scripts/deploy.sh 수정

### DIFF
--- a/kakaobase/scripts/deploy.sh
+++ b/kakaobase/scripts/deploy.sh
@@ -12,9 +12,6 @@ NEXT_PUBLIC_GOOGLE_ANALYTICS=$(jq -r .googleAnalytics imageDetail.json)
 aws ecr get-login-password --region "$AWS_REGION" | \
   sudo docker login --username AWS --password-stdin "$ECR_REPO"
 
-#이전 이미지 삭제
-sudo docker rmi "$FE_IMAGE_LATEST"
-
 # 📦 이미지 정보 읽기
 FE_IMAGE_LATEST=$(jq -r .frontendImage imageDetail.json)
 echo "Pulling FE image: $FE_IMAGE_LATEST"


### PR DESCRIPTION
Blue-Green 배포 과정에서 이미지 삭제가 필요없어
scrips/deploy.sh에 docker rmi 커맨드를 삭제함