### PR TITLE
[FIX] 로그인 안 된 사용자를 위한 페이지 구현

### DIFF
--- a/kakaobase/src/app/unauthorized/page.tsx
+++ b/kakaobase/src/app/unauthorized/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import SubmitButton from '@/shared/ui/button/SubmitButton';
+import HeaderMain from '@/widgets/header/HeaderMain';
+import { useRouter } from 'next/navigation';
+
+export default function Page() {
+  const router = useRouter();
+  function goLogin() {
+    router.push('/login');
+  }
+  function goHome() {
+    router.push('/');
+  }
+  return (
+    <div className="flex flex-col h-screen">
+      <HeaderMain />
+
+      <div className="flex h-screen justify-center items-center">
+        <div className="m-6">
+          <div className="flex flex-col gap-6 bg-containerColor p-6 rounded-xl">
+            <div className="flex text-center justify-center">
+              로그인이 필요합니다.
+              <br />
+              다시 로그인 해주세요.
+            </div>
+            <div className="flex flex-col items-center md:flex-row gap-4">
+              <SubmitButton text="로그인 하러 가기" onClick={goLogin} />
+              <SubmitButton text="메인 페이지로 가기" onClick={goHome} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/kakaobase/src/features/feeds/posts/hooks/usePostEditorForm.tsx
+++ b/kakaobase/src/features/feeds/posts/hooks/usePostEditorForm.tsx
@@ -49,12 +49,8 @@ export const usePostEditorForm = () => {
       showToast('게시글 등록 성공! ✌️');
       router.push(`/main`);
     } catch (e: any) {
-      if (e.response.data.error === 'unauthorized') {
-        showToast('로그인이 필요합니다. 😭');
-      } else {
-        showToast('게시글 업로드 실패! 잠시 후 다시 시도해 주세요. 😭');
-        router.push('/main');
-      }
+      showToast('게시글 업로드 실패! 잠시 후 다시 시도해 주세요. 😭');
+      router.push('/main');
     } finally {
       setLoading(false);
     }

--- a/kakaobase/src/shared/api/api.tsx
+++ b/kakaobase/src/shared/api/api.tsx
@@ -32,8 +32,8 @@ api.interceptors.response.use(
 
     if (origReq.url?.includes('/auth/tokens/refresh')) {
       // 리프레시 실패 시 바로 로그인 페이지로 이동
-      window.location.href = '/login';
-      return Promise.reject(error);
+      window.location.href = '/unauthorized';
+      return new Promise(() => {});
     }
 
     if (error.response?.status === 401 && !origReq._retry) {
@@ -54,7 +54,7 @@ api.interceptors.response.use(
         return api(origReq); //기존 api 요청 재시도
       } catch (refreshError) {
         processQueue(refreshError);
-        window.location.href = '/login';
+        window.location.href = '/unauthorized';
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
- 인터셉터에서 바로 로그인 페이지가 아닌 인증 안 됨 페이지로 이동하도록 함
- unauthorized 페이지에서 이동할 페이지를 선택하는 모달로 페이지 구현
- 게시글 작성 시 불필요한 catch문의 분기 제거

--- 

- 인터셉터에서 토스트를 띄우는 걸 생각했으나 zustand로 토스트를 이중 구현할 생각이 없음
- 인터셉터에서 훅을 사용할 수 없음 (훅 규칙)
- 사용자에게 선택권을 주는 것이 단순 트스트 이후 페이지 이동하는 것보다 ux가 좋다고 판단