### PR TITLE
[FEAT] 알림 로직 일부 구현

### DIFF
--- a/kakaobase/src/app/post/[postId]/page.tsx
+++ b/kakaobase/src/app/post/[postId]/page.tsx
@@ -22,10 +22,7 @@ export default function Page({ params }: { params: { postId: number } }) {
   return (
     <div className="flex flex-col h-screen">
       <Header label="게시글 상세" />
-      <div
-        className="overflow-y-auto flex flex-col min-h-0 mb-[4rem] h-screen"
-        data-scroll-area
-      >
+      <div className="overflow-y-auto flex flex-col h-screen" data-scroll-area>
         <div className="my-4">
           <PostCard post={data} />
         </div>

--- a/kakaobase/src/features/alarm/hooks/useAlarm.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarm.tsx
@@ -31,9 +31,9 @@ export default function useAlarm() {
       }
     });
 
-    return () => {
-      disconnectStomp();
-    };
+    // return () => {
+    //   disconnectStomp();
+    // };
   }, []);
 
   return { alarmList };

--- a/kakaobase/src/features/alarm/hooks/useAlarmSwipe.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarmSwipe.tsx
@@ -1,0 +1,77 @@
+import { useRef, useState } from 'react';
+
+export default function useAlarmSwipe({ is_read }: { is_read: boolean }) {
+  const [isRead, setRead] = useState(is_read);
+
+  const [showActions, setShowActions] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
+  const [offsetX, setOffsetX] = useState(0);
+  const startX = useRef<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  function handleTouchStart(e: React.TouchEvent) {
+    startX.current = e.touches[0].clientX;
+  }
+
+  function handleTouchMove(e: React.TouchEvent) {
+    if (startX.current === null) return;
+    const deltaX = startX.current - e.touches[0].clientX;
+    if (deltaX > 60) {
+      setShowActions(true);
+    }
+    setOffsetX(-deltaX);
+  }
+
+  function handleTouchEnd() {
+    setOffsetX(0);
+    startX.current = null;
+  }
+
+  // 마우스 이벤트
+  function handleMouseDown(e: React.MouseEvent) {
+    startX.current = e.clientX;
+    setIsDragging(true);
+  }
+
+  function handleMouseMove(e: React.MouseEvent) {
+    if (!isDragging || startX.current === null) return;
+    const deltaX = e.clientX - startX.current;
+    if (deltaX < -60) setShowActions(true);
+    setOffsetX(deltaX);
+  }
+
+  function handleMouseUp() {
+    setIsDragging(false);
+    setOffsetX(0);
+    startX.current = null;
+  }
+
+  function handleDelete() {
+    setIsDeleted(true);
+    // 실제 삭제 요청 API 호출
+  }
+
+  function handleClose() {
+    setShowActions(false);
+  }
+
+  function handleRead() {
+    setRead((prev) => !prev);
+    setShowActions(false);
+  }
+  return {
+    showActions,
+    isRead,
+    isDeleted,
+    offsetX,
+    handleTouchStart,
+    handleTouchEnd,
+    handleTouchMove,
+    handleClose,
+    handleDelete,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleRead,
+  };
+}

--- a/kakaobase/src/features/alarm/lib/socket.tsx
+++ b/kakaobase/src/features/alarm/lib/socket.tsx
@@ -10,16 +10,12 @@ export const connectStomp = (onMessage: (msg: IMessage) => void) => {
   stompClient = new Client({
     webSocketFactory: () => socket,
     reconnectDelay: reconnectTime,
-    debug: (str) => console.log('stomp debug :', str),
     onConnect: () => {
-      console.log('서버와 stomp 연결 완료');
-
       stompClient?.subscribe(
         '/user/queue/notification',
         (message: IMessage) => {
           try {
-            const parsed = JSON.parse(message.body);
-            console.log('알림 이벤트:', parsed.event);
+            const parsed = message;
             onMessage(parsed);
           } catch (err) {
             console.error('메시지 파싱 오류:', err);

--- a/kakaobase/src/features/alarm/types/AlarmEvent.tsx
+++ b/kakaobase/src/features/alarm/types/AlarmEvent.tsx
@@ -8,7 +8,6 @@ export type AlarmDetailEvent =
 
 export type AlarmEvent =
   | 'notification.fetch'
-  | 'notification.remove'
   | 'notification.read.ack'
   | 'notification.read.nack'
   | 'notification.remove.ack'

--- a/kakaobase/src/features/alarm/ui/AlarmAction.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmAction.tsx
@@ -1,0 +1,17 @@
+import { LucideIcon } from 'lucide-react';
+
+interface AlarmActionParams {
+  icon: LucideIcon;
+  fn: () => void;
+}
+
+export default function AlarmAction({ icon: Icon, fn }: AlarmActionParams) {
+  return (
+    <div
+      className="flex w-6 h-6 bg-innerContainerColor hover:bg-myBlue hover:text-textOnBlue rounded-full items-center justify-center cursor-pointer"
+      onClick={fn}
+    >
+      <Icon size={14} />
+    </div>
+  );
+}

--- a/kakaobase/src/features/alarm/ui/AlarmContent.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmContent.tsx
@@ -1,0 +1,14 @@
+import { AlarmDetailEvent } from '../types/AlarmEvent';
+
+export default function AlarmContent({ data }: { data: any }) {
+  const event = data.event as AlarmDetailEvent;
+  if (event === 'comment.created' || event === 'recomment.created')
+    return data.data.content;
+  else if (event === 'comment.like.created')
+    return '회원님의 댓글을 좋아합니다.';
+  else if (event === 'post.like.created')
+    return '회원님의 게시글을 좋아합니다.';
+  else if (event === 'recomment.like.created')
+    return '회원님의 대댓글을 좋아합니다.';
+  return '회원님을 팔로우하기 시작했습니다.';
+}

--- a/kakaobase/src/features/alarm/ui/AlarmList.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmList.tsx
@@ -1,24 +1,22 @@
 'use client';
+import LoadingSmall from '@/shared/ui/LoadingSmall';
 import useAlarm from '../hooks/useAlarm';
 import AlarmItem from './AlarmItem';
 
 export default function AlarmList() {
   const { alarmList } = useAlarm();
+
+  if (!alarmList || alarmList === null)
+    return (
+      <div className="h-screen">
+        <LoadingSmall />
+      </div>
+    );
   return (
     <div className="flex flex-col w-full h-screen">
-      {/* {alarmList.map((alarms, idx) => (
+      {alarmList.map((alarms, idx) => (
         <AlarmItem data={alarms} key={idx} />
-      ))} */}
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
-      <AlarmItem data={alarmList} />
+      ))}
     </div>
   );
 }

--- a/kakaobase/src/features/alarm/ui/AlarmNameParticle.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmNameParticle.tsx
@@ -1,0 +1,11 @@
+import { AlarmDetailEvent } from '../types/AlarmEvent';
+
+export default function AlarmNameParticle({
+  event,
+}: {
+  event: AlarmDetailEvent;
+}) {
+  if (event === 'comment.created') return '님이 댓글을 남겼습니다.';
+  else if (event === 'recomment.created') return '님이 대댓글을 남겼습니다.';
+  return '님이';
+}

--- a/kakaobase/src/features/alarm/ui/AlarmProfile.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmProfile.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+
+export default function AlarmProfile({ sender }: { sender: any }) {
+  const imageUrl = sender.image_url;
+
+  if (imageUrl === null)
+    return (
+      <div>
+        <Image
+          src="/logo_square.svg"
+          alt="프로필"
+          fill
+          className="object-fit flex rounded-xl border-innerContainerColor border-2 p-1"
+        />
+      </div>
+    );
+  else
+    return (
+      <div>
+        <Image
+          src={imageUrl}
+          alt="프로필"
+          fill
+          className="object-fit flex rounded-xl"
+        />
+      </div>
+    );
+}


### PR DESCRIPTION
# 완료한 것
- 알림 목록 조회 구현 완료

### 알림 비즈니스 로직
- AlarmProfile, AlarmNameParticle, AlarmContent 분리
- AlarmAction으로 알림 처리할 버튼 컴포넌트 분리하여 구현
- AlarmActions를 띄우는 스와이프 로직 분리

### 알림 로직 및 디자인 수정
- 알림 훅 - 연결 끊는 거 우선 임시 주석 처리
- 알림 이벤트 type에 notification.remove 제거
- 알림 목록 컴포넌트 수정 (하드 코딩 제거)

### 게시글 상세 페이지 디자인 수정
- page에서 하단 마진 제거 (commentInput 변경에 따른 게시글 상세 페이지 디자인 수정)

# 남은 것
- 알림 삭제, 읽기 및 페이지 이동