### PR TITLE
[FIX] 알림 안정화 

### DIFF
--- a/kakaobase/src/app/providers.tsx
+++ b/kakaobase/src/app/providers.tsx
@@ -3,10 +3,8 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
 import { ToastProvider } from '@/shared/hooks/ToastContext';
 import { queryClient } from '@/shared/api/queryClient';
-import useAlarm from '@/features/alarm/hooks/useAlarm';
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  useAlarm();
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <ToastProvider>

--- a/kakaobase/src/features/alarm/hooks/useAlarm.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarm.tsx
@@ -1,20 +1,14 @@
-// src/hooks/useNotification.ts
 import { useEffect, useState } from 'react';
 import { connectStomp, disconnectStomp } from '../lib/socket';
 import { IMessage } from '@stomp/stompjs';
-import { AlarmEvent } from '../types/AlarmEvent';
-
-export interface NotificationData {
-  event: AlarmEvent;
-  data: any;
-}
+import { AlarmResponse } from '../types/AlarmResponse';
 
 export default function useAlarm() {
-  const [alarmList, setAlarmList] = useState<NotificationData[]>([]);
+  const [alarmList, setAlarmList] = useState<AlarmResponse[]>([]);
 
   useEffect(() => {
     connectStomp((msg: IMessage) => {
-      const parsed: NotificationData = JSON.parse(msg.body);
+      const parsed: AlarmResponse = JSON.parse(msg.body);
 
       switch (parsed.event) {
         case 'notification.fetch':
@@ -31,9 +25,9 @@ export default function useAlarm() {
       }
     });
 
-    // return () => {
-    //   disconnectStomp();
-    // };
+    return () => {
+      disconnectStomp();
+    }; //메모리 누수 방지
   }, []);
 
   return { alarmList };

--- a/kakaobase/src/features/alarm/hooks/useAlarmSwipe.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarmSwipe.tsx
@@ -2,13 +2,14 @@ import { useRef, useState } from 'react';
 
 export default function useAlarmSwipe({ is_read }: { is_read: boolean }) {
   const [isRead, setRead] = useState(is_read);
-
   const [showActions, setShowActions] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
   const [offsetX, setOffsetX] = useState(0);
   const startX = useRef<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const wasDragged = useRef(false); // 추가
 
+  //터치 이벤트
   function handleTouchStart(e: React.TouchEvent) {
     startX.current = e.touches[0].clientX;
   }
@@ -36,6 +37,7 @@ export default function useAlarmSwipe({ is_read }: { is_read: boolean }) {
   function handleMouseMove(e: React.MouseEvent) {
     if (!isDragging || startX.current === null) return;
     const deltaX = e.clientX - startX.current;
+    if (Math.abs(deltaX) > 4) wasDragged.current = true;
     if (deltaX < -60) setShowActions(true);
     setOffsetX(deltaX);
   }
@@ -44,6 +46,10 @@ export default function useAlarmSwipe({ is_read }: { is_read: boolean }) {
     setIsDragging(false);
     setOffsetX(0);
     startX.current = null;
+
+    setTimeout(() => {
+      wasDragged.current = false;
+    }, 0);
   }
 
   function handleDelete(e: React.MouseEvent<HTMLElement>) {
@@ -67,6 +73,7 @@ export default function useAlarmSwipe({ is_read }: { is_read: boolean }) {
     isRead,
     isDeleted,
     offsetX,
+    wasDragged,
     handleTouchStart,
     handleTouchEnd,
     handleTouchMove,

--- a/kakaobase/src/features/alarm/lib/socket.tsx
+++ b/kakaobase/src/features/alarm/lib/socket.tsx
@@ -11,7 +11,9 @@ export const connectStomp = (onMessage: (msg: IMessage) => void) => {
     webSocketFactory: () => socket,
     reconnectDelay: reconnectTime,
     onConnect: () => {
-      stompClient?.subscribe(
+      if (!stompClient || !stompClient.connected) return;
+
+      stompClient.subscribe(
         '/user/queue/notification',
         (message: IMessage) => {
           try {
@@ -22,7 +24,7 @@ export const connectStomp = (onMessage: (msg: IMessage) => void) => {
           }
         }
       );
-      stompClient?.subscribe('/user/queue/error', (message: IMessage) => {
+      stompClient.subscribe('/user/queue/error', (message: IMessage) => {
         try {
           const parsed = JSON.parse(message.body);
           console.log('[알림 에러]', parsed.message || parsed.error);

--- a/kakaobase/src/features/alarm/types/AlarmResponse.tsx
+++ b/kakaobase/src/features/alarm/types/AlarmResponse.tsx
@@ -1,0 +1,6 @@
+import { AlarmEvent } from "./AlarmEvent";
+
+export interface AlarmResponse {
+    event: AlarmEvent;
+    data: any;
+}

--- a/kakaobase/src/features/alarm/ui/AlarmItem.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmItem.tsx
@@ -21,6 +21,7 @@ export default function AlarmItem({ data }: { data: any }) {
     showActions,
     isDeleted,
     offsetX,
+    wasDragged,
     handleClose,
     handleDelete,
     handleMouseDown,
@@ -54,9 +55,24 @@ export default function AlarmItem({ data }: { data: any }) {
     >
       <div
         className="flex px-6 py-4 justify-between gap-2 w-full items-center"
-        onClick={event === 'following.created' ? goToProfile : goToPost}
+        onClick={(e) => {
+          if (wasDragged.current) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
+
+          if (event === 'following.created') {
+            goToProfile();
+          } else {
+            goToPost();
+          }
+        }}
       >
         <div className="flex gap-2 items-center min-w-0">
+          <div
+            className={`w-2 h-2 rounded-full ${!isRead && 'bg-myBlue'}`}
+          ></div>
           <div className="relative w-10 h-10 rounded-xl shrink-0">
             <AlarmProfile sender={sender} />
           </div>

--- a/kakaobase/src/features/alarm/ui/AlarmList.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmList.tsx
@@ -14,8 +14,8 @@ export default function AlarmList() {
     );
   return (
     <div className="flex flex-col w-full h-screen">
-      {alarmList.map((alarms, idx) => (
-        <AlarmItem data={alarms} key={idx} />
+      {alarmList.map((alarm, idx) => (
+        <AlarmItem data={alarm} key={idx} />
       ))}
     </div>
   );


### PR DESCRIPTION
## 알림 목록 새로 고침 시 렌더링 안 되는 문제 해결
- providers.tsx에서 제거

## 사소한 알림 로직 리팩토링
- 알림 응답 데이터 타입 분리
- 메모리 누수 방지를 위해 언마운트될 때 함수 주석 무효화
- 소켓 연결을 보장하기 위해 조건문 추가 (socket.tsx)
- alarmList - 복수에서 단수형으로 변경 (알림 아이템 하나이기 때문)

## 디자인 수정 및 마우스 이벤트 로직 추가
- 읽지 않은 알림의 경우 파란색 동그라미 추가
- 드래그 시 클릭처럼 페이지 이동하는 현상 발생 -> 드래그 상태를 추가하여 페이지 이동 방지

## 남은 것
- 401 에러 (로그인 안 된 사용자일 경우 리프레시 후 소켓 재연결 시도)