### PR TITLE
[FEAT] 알림 로직 구현 완료

### DIFF
--- a/kakaobase/src/app/providers.tsx
+++ b/kakaobase/src/app/providers.tsx
@@ -3,8 +3,10 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
 import { ToastProvider } from '@/shared/hooks/ToastContext';
 import { queryClient } from '@/shared/api/queryClient';
+import useAlarm from '@/features/alarm/hooks/useAlarm';
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  useAlarm();
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <ToastProvider>

--- a/kakaobase/src/features/alarm/hooks/useAlarmRouting.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarmRouting.tsx
@@ -5,17 +5,21 @@ export default function useAlarmRouting({ data }: { data: any }) {
   const router = useRouter();
 
   function goToPost() {
-    sendNotificationCommand('notification.read', {
-      id: data.id,
-      timestamp: new Date().toISOString().split('.')[0],
-    });
+    if (!data.is_read) {
+      sendNotificationCommand('notification.read', {
+        id: data.id,
+        timestamp: new Date().toISOString().split('.')[0],
+      });
+    }
     router.push(`/post/${data.target_id}`);
   }
   function goToProfile() {
-    sendNotificationCommand('notification.read', {
-      id: data.id,
-      timestamp: new Date().toISOString().split('.')[0],
-    });
+    if (!data.is_read) {
+      sendNotificationCommand('notification.read', {
+        id: data.id,
+        timestamp: new Date().toISOString().split('.')[0],
+      });
+    }
     router.push(`/profile/${data.sender.id}`);
   }
   return { goToPost, goToProfile };

--- a/kakaobase/src/features/alarm/hooks/useAlarmRouting.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarmRouting.tsx
@@ -1,12 +1,21 @@
 import { useRouter } from 'next/navigation';
+import { sendNotificationCommand } from '../lib/socket';
 
 export default function useAlarmRouting({ data }: { data: any }) {
   const router = useRouter();
 
   function goToPost() {
+    sendNotificationCommand('notification.read', {
+      id: data.id,
+      timestamp: new Date().toISOString().split('.')[0],
+    });
     router.push(`/post/${data.target_id}`);
   }
   function goToProfile() {
+    sendNotificationCommand('notification.read', {
+      id: data.id,
+      timestamp: new Date().toISOString().split('.')[0],
+    });
     router.push(`/profile/${data.sender.id}`);
   }
   return { goToPost, goToProfile };

--- a/kakaobase/src/features/alarm/hooks/useAlarmSwipe.tsx
+++ b/kakaobase/src/features/alarm/hooks/useAlarmSwipe.tsx
@@ -55,7 +55,7 @@ export default function useAlarmSwipe({ data }: { data: any }) {
 
   function handleDelete(e: React.MouseEvent<HTMLElement>) {
     e.stopPropagation();
-    sendNotificationCommand('notification.delete', {
+    sendNotificationCommand('notification.remove', {
       id: data.id,
       timestamp: new Date().toISOString().split('.')[0],
     });

--- a/kakaobase/src/features/alarm/stores/alarmStore.tsx
+++ b/kakaobase/src/features/alarm/stores/alarmStore.tsx
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { AlarmItem } from '../types/AlarmFetchResponse';
+
+export interface AlarmState {
+  cnt: number;
+  alarmList: AlarmItem[];
+  setAlarmInfo: (
+    updater: Partial<AlarmState> | ((prev: AlarmState) => Partial<AlarmState>)
+  ) => void;
+  clear: () => void;
+}
+
+export const useAlarmStore = create<AlarmState>()((set) => ({
+  cnt: 0,
+  alarmList: [],
+  setAlarmInfo: (updater) =>
+    set((state) => {
+      const updates = typeof updater === 'function' ? updater(state) : updater;
+      return { ...state, ...updates };
+    }),
+  clear: () =>
+    set({
+      cnt: 0,
+      alarmList: [],
+    }),
+}));

--- a/kakaobase/src/features/alarm/types/AlarmFetchResponse.tsx
+++ b/kakaobase/src/features/alarm/types/AlarmFetchResponse.tsx
@@ -1,0 +1,29 @@
+import { AlarmDetailEvent } from './AlarmEvent';
+
+export interface AlarmFetchData {
+  unread_count: number;
+  notifications: AlarmItem[];
+}
+
+export interface AlarmItem {
+  type: string;
+  event: AlarmDetailEvent;
+  data: AlarmItemData;
+}
+
+export interface AlarmItemData {
+  id: number;
+  sender: Sender;
+  target_id: number;
+  content?: string;
+  is_read: boolean;
+  timestamp: string;
+}
+
+export interface Sender {
+  id: number;
+  name?: string;
+  nickname: string;
+  image_url: string | null;
+  is_followed?: boolean;
+}

--- a/kakaobase/src/features/alarm/types/AlarmResponse.tsx
+++ b/kakaobase/src/features/alarm/types/AlarmResponse.tsx
@@ -1,6 +1,20 @@
-import { AlarmEvent } from "./AlarmEvent";
+import { AlarmEvent } from './AlarmEvent';
+import { AlarmFetchData } from './AlarmFetchResponse';
 
-export interface AlarmResponse {
-    event: AlarmEvent;
-    data: any;
+export type AlarmResponse =
+  | {
+      type: string;
+      event: 'notification.fetch';
+      data: AlarmFetchData;
+    }
+  | {
+      type: string;
+      event: Exclude<AlarmEvent, 'notification.fetch'>;
+      data: AlarmDefaultData;
+    };
+
+export interface AlarmDefaultData {
+  id: number;
+  message: string;
+  timestamp: string;
 }

--- a/kakaobase/src/features/alarm/ui/AlarmItem.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmItem.tsx
@@ -10,8 +10,9 @@ import AlarmAction from './AlarmAction';
 import AlarmNameParticle from './AlarmNameParticle';
 import useAlarmSwipe from '../hooks/useAlarmSwipe';
 import useAlarmRouting from '../hooks/useAlarmRouting';
+import { AlarmItem as AlarmItemType } from '../types/AlarmFetchResponse';
 
-export default function AlarmItem({ data }: { data: any }) {
+export default function AlarmItem({ data }: { data: AlarmItemType }) {
   const alarm = data.data;
   const sender = data.data.sender;
   const event = data.event;
@@ -96,7 +97,7 @@ export default function AlarmItem({ data }: { data: any }) {
           </div>
         </div>
 
-        {event === 'following.created' && (
+        {event === 'following.created' && sender.is_followed && (
           <FollowButtonSmall isFollowing={sender.is_followed} id={sender.id} />
         )}
 

--- a/kakaobase/src/features/alarm/ui/AlarmList.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmList.tsx
@@ -1,10 +1,10 @@
 'use client';
 import LoadingSmall from '@/shared/ui/LoadingSmall';
-import useAlarm from '../hooks/useAlarm';
 import AlarmItem from './AlarmItem';
+import { useAlarmStore } from '../stores/alarmStore';
 
 export default function AlarmList() {
-  const { alarmList } = useAlarm();
+  const { alarmList } = useAlarmStore();
 
   if (!alarmList || alarmList === null)
     return (
@@ -14,8 +14,8 @@ export default function AlarmList() {
     );
   return (
     <div className="flex flex-col w-full h-screen">
-      {alarmList.map((alarm, idx) => (
-        <AlarmItem data={alarm} key={idx} />
+      {alarmList.map((alarm) => (
+        <AlarmItem data={alarm} key={alarm.data.id} />
       ))}
     </div>
   );

--- a/kakaobase/src/widgets/navbar/NavItem.tsx
+++ b/kakaobase/src/widgets/navbar/NavItem.tsx
@@ -1,5 +1,7 @@
+import { useAlarmStore } from '@/features/alarm/stores/alarmStore';
+import { cn } from '@/shared/lib/utils';
 import clsx from 'clsx';
-import { LucideIcon } from 'lucide-react';
+import { Bell, LucideIcon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 
@@ -13,6 +15,7 @@ export default function NavItem({
   const pathName = usePathname();
   const router = useRouter();
   const isActive = pathName === path;
+  const { cnt } = useAlarmStore();
 
   const handleClick = () => {
     if (path) router.push(path);
@@ -35,6 +38,11 @@ export default function NavItem({
           isActive ? 'text-myBlue' : 'text-iconColor hover:text-textColor'
         )}
       />
+      {Icon === Bell && cnt > 0 && (
+        <div className="w-4 h-4 absolute rounded-full bg-myBlue text-textOnBlue text-xs mb-5 ml-4">
+          {cnt}
+        </div>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## 알림 응답 타입 정의
- fetch, remove, read에 맞는 응답 형태 정의
## 로직 수정
- 알림 타겟 하위 페이지로 이동할 때 알림 읽음 표시하게 하기
- delete 아니고 remove 경로로 보내야 함
- 타입 변경에 따른 구체화 (AlarmItem)

## 알림 전역 상태로 변경
- 알림 개수를 네비게이션 바에 표시하기 위해 전역 상태 관리 추가
- 네비게이션 바에 적용
- 추가 message가 올 때 인덱스가 맞지 않는 문제가 발생하여 idx -> 실제 id로 변경
- 알림 페이지에서만 소켓 연결하는 것이 아닌 서비스 접속 중일 경우 항상 연결 상태이도록 전역으로 커스텀 훅 호출 변경 (providers.tsx)

## 추가 메시지 응답 및 알림 개수 대응
- 처음 목록 fetch일 경우, 목록 저장
- 읽은 경우, 삭제인 경우 목록 및 개수에 반영
- 추가 알림 메시지 응답일 경우 목록 및 개수에 반영
- 읽은 알림 클릭 시 알림 읽음 처리되는 이슈 해결