### PR TITLE
[FIX] 무한 새로고침 문제 해결

### DIFF
--- a/kakaobase/src/shared/api/api.tsx
+++ b/kakaobase/src/shared/api/api.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { AxiosError, AxiosRequestConfig } from 'axios';
+import Router from 'next/router';
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
@@ -32,7 +33,7 @@ api.interceptors.response.use(
 
     if (origReq.url?.includes('/auth/tokens/refresh')) {
       // 리프레시 실패 시 바로 로그인 페이지로 이동
-      window.location.href = '/unauthorized';
+      Router.replace('/unauthorized');
       return new Promise(() => {});
     }
 


### PR DESCRIPTION
- 소켓 연결 401 실패 후, 토큰 재발급도 실패할 경우, unauthorized 페이지로 무한 이동하고 이 과정이 반복되는 문제가 있었음 -> Router 사용하여 해결