### PR TITLE
[FIX] 배포 서버에서 build 명령어 충돌

### DIFF
--- a/kakaobase/package.json
+++ b/kakaobase/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "node server.js",
+    "dev": "NODE_ENV=development node server.js",
     "type-check": "tsc --noEmit",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "start": "next start",
+    "start:local": "NODE_ENV=production FORCE_HTTPS=true node server.js",
     "lint": "next lint"
   },
   "dependencies": {

--- a/kakaobase/server.js
+++ b/kakaobase/server.js
@@ -1,22 +1,34 @@
 const fs = require('fs');
+const http = require('http');
 const https = require('https');
 const next = require('next');
 
 const dev = process.env.NODE_ENV !== 'production';
+const forceHttps = process.env.FORCE_HTTPS === 'true';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
-const httpsOptions = {
-  key: fs.readFileSync('./cert/localhost-key.pem'),
-  cert: fs.readFileSync('./cert/localhost.pem'),
+const certPath = {
+  key: './cert/localhost-key.pem',
+  cert: './cert/localhost.pem',
 };
 
 app.prepare().then(() => {
-  https
-    .createServer(httpsOptions, (req, res) => {
-      handle(req, res);
-    })
-    .listen(3000, () => {
-      console.log('HTTPS 개발 서버 시작됨: https://localhost:3000');
+  if (
+    (dev || forceHttps) &&
+    fs.existsSync(certPath.key) &&
+    fs.existsSync(certPath.cert)
+  ) {
+    const options = {
+      key: fs.readFileSync(certPath.key),
+      cert: fs.readFileSync(certPath.cert),
+    };
+    https.createServer(options, handle).listen(3000, () => {
+      console.log(`HTTPS Server: https://localhost:3000`);
     });
+  } else {
+    http.createServer(handle).listen(3000, () => {
+      console.log(`HTTP Server:  http://localhost:3000`);
+    });
+  }
 });


### PR DESCRIPTION
- 배포 서버에서 npm start로 실행하는데 멋대로 바꿔서 배포 서버에서 실행하는 명령어가 바뀌어 502 gateway를 뱉음
- start:local 명령어 만들게 됨
- server.js도 forceHttps 조건을 추가하여 분기