### PR TITLE
[FIX] 로그인 에러 핸들링

### DIFF
--- a/kakaobase/src/features/auth/api/login.tsx
+++ b/kakaobase/src/features/auth/api/login.tsx
@@ -1,5 +1,6 @@
 import { Course } from '@/shared/types/Course';
 import api from '@/shared/api/api';
+import { AxiosError } from 'axios';
 
 interface LoginRequest {
   email: string;
@@ -17,6 +18,11 @@ interface LoginResponse {
 }
 
 export async function login(payload: LoginRequest): Promise<LoginResponse> {
-  const response = await api.post('/auth/tokens', payload);
-  return response.data;
+  try {
+    const response = await api.post('/auth/tokens', payload);
+    return response.data;
+  } catch (e: unknown) {
+    if (e instanceof AxiosError) throw e.response?.data;
+    throw e;
+  }
 }

--- a/kakaobase/src/features/auth/hooks/useLoginForm.tsx
+++ b/kakaobase/src/features/auth/hooks/useLoginForm.tsx
@@ -43,7 +43,7 @@ export default function useLoginForm() {
       });
       router.push('/');
     } catch (e: any) {
-      const errorCode = e?.response?.data?.error;
+      const errorCode = e?.error;
       if (errorCode === 'invalid_password') {
         setError('password', {
           type: 'manual',

--- a/kakaobase/src/shared/api/api.tsx
+++ b/kakaobase/src/shared/api/api.tsx
@@ -31,6 +31,13 @@ api.interceptors.response.use(
   ) => {
     const origReq = error.config!;
 
+    if (
+      (!origReq.url?.includes('refresh') &&
+        origReq.url?.includes('/auth/tokens')) ||
+      origReq.url?.endsWith('/users')
+    ) {
+      return Promise.reject(error);
+    }
     if (origReq.url?.includes('/auth/tokens/refresh')) {
       // 리프레시 실패 시 바로 로그인 페이지로 이동
       Router.replace('/unauthorized');


### PR DESCRIPTION
- 인터셉터에서 401 에러가 로그인 안 된 상황에서의 api일 때 토큰 재발급을 시도하면 안 됨
- 회원가입과 로그인 api는 그대로 promise를 반환하도록 조건 분기함