### PR TITLE
[REFACTOR] 리팩토링 / 파라미터 범위 축소 / PostCard,PostList 메모이제이션

### DIFF
--- a/kakaobase/src/app/layout.tsx
+++ b/kakaobase/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Providers } from './providers';
 import Image from 'next/image';
 import GoogleAnalytics from '@/shared/lib/GoogleAnalytics';
+import Surfing from '@/widgets/background/Surfing';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://kakaobase.com'),
@@ -48,14 +49,7 @@ export default async function RootLayout({
         )}
         <div className="absolute flex items-end bottom-40">
           <div className="relative h-24 w-24">
-            <Image
-              src="/chunsik.png"
-              alt="surfing"
-              fill
-              sizes="(max-width : 1024px) 10vw, 96px"
-              priority
-              className="surfing object-contain hidden lg:block"
-            />
+            <Surfing />
           </div>
         </div>
         <div className="box hidden lg:block">
@@ -72,7 +66,6 @@ export default async function RootLayout({
                   alt="로고"
                   fill
                   sizes="(max-width: 1024px) 20vw, 288px"
-                  priority
                   className="object-contain"
                 />
               </div>

--- a/kakaobase/src/app/not-found.tsx
+++ b/kakaobase/src/app/not-found.tsx
@@ -1,13 +1,10 @@
 'use client';
+import useRoutings from '@/shared/hooks/useRoutings';
 import SubmitButton from '@/shared/ui/button/SubmitButton';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 
 export default function NotFound() {
-  const router = useRouter();
-  function goHome() {
-    router.push('/');
-  }
+  const { goHome } = useRoutings();
 
   return (
     <div className="flex w-full h-screen flex-col items-center justify-center gap-6">

--- a/kakaobase/src/features/account/hooks/useUserInfo.tsx
+++ b/kakaobase/src/features/account/hooks/useUserInfo.tsx
@@ -1,10 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { accountQueries } from '../api/accountQueries';
 
 export default function useUserInfo({ userId }: { userId: number }) {
-  const router = useRouter();
   const [isOpen, setOpen] = useState(false);
 
   const userInfoMethods = useQuery(accountQueries.userInfo(userId));
@@ -13,14 +11,9 @@ export default function useUserInfo({ userId }: { userId: number }) {
     setOpen((prev) => !prev);
   }
 
-  function navEdit() {
-    router.push(`${userId}/edit`);
-  }
-
   return {
     ...userInfoMethods,
     handleModal,
-    navEdit,
     isOpen,
   };
 }

--- a/kakaobase/src/features/account/ui/MyPageWrapper.tsx
+++ b/kakaobase/src/features/account/ui/MyPageWrapper.tsx
@@ -12,7 +12,7 @@ import useRoutings from '@/shared/hooks/useRoutings';
 import useUserInfo from '../hooks/useUserInfo';
 
 export default function MyPageWrapper({ userId }: { userId: number }) {
-  const { data, isPending, handleModal, navEdit, isOpen } = useUserInfo({
+  const { data, isPending, handleModal, isOpen } = useUserInfo({
     userId,
   });
 

--- a/kakaobase/src/features/alarm/ui/AlarmItem.tsx
+++ b/kakaobase/src/features/alarm/ui/AlarmItem.tsx
@@ -91,7 +91,7 @@ export default function AlarmItem({ data }: { data: AlarmItemType }) {
                 <AlarmContent data={data} />
               </div>
               <div className="shrink-0 text-textOpacity50">
-                {formatDate(alarm.timestamp, false)}
+                {formatDate(alarm.timestamp)}
               </div>
             </div>
           </div>

--- a/kakaobase/src/features/chat/ui/BotChat.tsx
+++ b/kakaobase/src/features/chat/ui/BotChat.tsx
@@ -23,7 +23,7 @@ export default function BotChat({
         <div className="text-sm px-3 py-2 rounded-xl max-w-[64%] flex bg-myLightBlue text-textOnLight whitespace-pre-wrap break-all">
           {text}
         </div>
-        <div className="text-xs opacity-40">{formatDate(time, false)}</div>
+        <div className="text-xs opacity-40">{formatDate(time)}</div>
       </div>
     </div>
   );

--- a/kakaobase/src/features/chat/ui/MyChat.tsx
+++ b/kakaobase/src/features/chat/ui/MyChat.tsx
@@ -4,7 +4,7 @@ export default function MyChat({ text, time }: { text: string; time: string }) {
   return (
     <div className="relative px-6 py-2 flex flex-col gap-2 w-full">
       <div className="flex gap-2 justify-end items-end">
-        <div className="text-xs opacity-40">{formatDate(time, false)}</div>
+        <div className="text-xs opacity-40">{formatDate(time)}</div>
         <div className="text-sm px-3 py-2 rounded-xl max-w-[64%] flex bg-myBlue text-textOnBlue whitespace-pre-wrap break-all">
           {text}
         </div>

--- a/kakaobase/src/features/feeds/comments/ui/CommentList.tsx
+++ b/kakaobase/src/features/feeds/comments/ui/CommentList.tsx
@@ -27,7 +27,7 @@ export default function CommentList() {
   });
 
   return (
-    <div className="flex flex-col py-4">
+    <div className="flex flex-col pt-4 pb-20">
       {data?.pages.flat().map((post) => (
         <PostCard key={post.id} post={post} />
       ))}

--- a/kakaobase/src/features/feeds/comments/ui/RecommentList.tsx
+++ b/kakaobase/src/features/feeds/comments/ui/RecommentList.tsx
@@ -6,8 +6,13 @@ import useScrollHook from '@/shared/hooks/useScrollHook';
 import { recommentFormStateStore } from '../stores/recommentFormStateStore';
 import { feedQueries } from '../../api/feedQueries';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { memo } from 'react';
 
-export default function RecommentList({ commentId }: { commentId: number }) {
+const RecommentList = memo(function RecommentList({
+  commentId,
+}: {
+  commentId: number;
+}) {
   const {
     data,
     isPending,
@@ -37,4 +42,6 @@ export default function RecommentList({ commentId }: { commentId: number }) {
       {!hasNextPage && isPending && <LoadingSmall />}
     </div>
   );
-}
+});
+
+export default RecommentList;

--- a/kakaobase/src/features/feeds/lib/formatDate.tsx
+++ b/kakaobase/src/features/feeds/lib/formatDate.tsx
@@ -1,7 +1,4 @@
-export default function formatDate(
-  createdAt: string,
-  isNarrow: boolean
-): string {
+export default function formatDate(createdAt: string): string {
   const date = new Date(createdAt);
   const now = new Date();
 
@@ -23,7 +20,6 @@ export default function formatDate(
     const month = date.getMonth() + 1;
     const day = date.getDate();
 
-    if (isNarrow) return `${month}월 ${day}일`;
-    else return `${year}년 ${month}월 ${day}일`;
+    return `${year}년 ${month}월 ${day}일`;
   }
 }

--- a/kakaobase/src/features/feeds/posts/ui/PostList.tsx
+++ b/kakaobase/src/features/feeds/posts/ui/PostList.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { memo } from 'react';
 import PostCard from '../../ui/PostCard';
 import usePostList from '../hooks/usePostList';
 import useScrollHook from '@/shared/hooks/useScrollHook';
 import LoadingSmall from '@/shared/ui/LoadingSmall';
 
-export default function PostList() {
+const PostList = memo(function PostList() {
   const {
     data,
     fetchNextPage,
@@ -43,4 +44,6 @@ export default function PostList() {
       )}
     </div>
   );
-}
+});
+
+export default PostList;

--- a/kakaobase/src/features/feeds/ui/MiddleBar.tsx
+++ b/kakaobase/src/features/feeds/ui/MiddleBar.tsx
@@ -1,13 +1,8 @@
-import { usePathname } from 'next/navigation';
-
 export default function MiddleBar() {
-  const path = usePathname();
   return (
     <div className="py-4 px-6 border-y-[1px] border-textOpacity50 flex items-center">
       <div className="flex gap-4 text-textColor">
-        <div className="font-bold text-lg">
-          {path.includes('comment') ? '대댓글' : '댓글'}
-        </div>
+        <div className="font-bold text-lg">댓글</div>
       </div>
     </div>
   );

--- a/kakaobase/src/features/feeds/ui/PostCard.tsx
+++ b/kakaobase/src/features/feeds/ui/PostCard.tsx
@@ -5,12 +5,13 @@ import clsx from 'clsx';
 import Linkify from 'react-linkify';
 import { usePathname } from 'next/navigation';
 import CountsInfo from './CountsInfo';
-import { UserProfile, UserInfo } from './UserInfo';
 import summaryCondition from '../posts/lib/summaryCondition';
 import { Comment, PostEntity } from '@/features/feeds/types/post';
 import RecommentList from '../comments/ui/RecommentList';
 import YoutubeFrame from './YoutubeFrame';
 import useRoutings from '@/shared/hooks/useRoutings';
+import UserProfileImage from './UserProfileImage';
+import UserInfo from './UserInfo';
 
 export default function PostCard({ post }: { post: PostEntity }) {
   const { goPostDetail } = useRoutings();
@@ -41,7 +42,7 @@ export default function PostCard({ post }: { post: PostEntity }) {
           )}
           onClick={navDetail}
         >
-          <UserProfile post={post} />
+          <UserProfileImage post={post} />
           <div className="w-full flex flex-col gap-2 text-textColor">
             <UserInfo post={post} />
             <div>

--- a/kakaobase/src/features/feeds/ui/PostCard.tsx
+++ b/kakaobase/src/features/feeds/ui/PostCard.tsx
@@ -12,8 +12,9 @@ import YoutubeFrame from './YoutubeFrame';
 import useRoutings from '@/shared/hooks/useRoutings';
 import UserProfileImage from './UserProfileImage';
 import UserInfo from './UserInfo';
+import { memo } from 'react';
 
-export default function PostCard({ post }: { post: PostEntity }) {
+const PostCard = memo(function PostCard({ post }: { post: PostEntity }) {
   const { goPostDetail } = useRoutings();
   const path = usePathname();
 
@@ -42,7 +43,7 @@ export default function PostCard({ post }: { post: PostEntity }) {
           )}
           onClick={navDetail}
         >
-          <UserProfileImage post={post} />
+          <UserProfileImage id={post.userId} profileUrl={post.userProfileUrl} />
           <div className="w-full flex flex-col gap-2 text-textColor">
             <UserInfo post={post} />
             <div>
@@ -106,4 +107,6 @@ export default function PostCard({ post }: { post: PostEntity }) {
       <RecommentList commentId={post.id} />
     </div>
   );
-}
+});
+
+export default PostCard;

--- a/kakaobase/src/features/feeds/ui/UserInfo.tsx
+++ b/kakaobase/src/features/feeds/ui/UserInfo.tsx
@@ -1,48 +1,17 @@
-import { Trash2, User } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import FollowButtonSmall from '@/features/follows/ui/FollowButtonSmall';
 import formatDate from '../lib/formatDate';
-import Image from 'next/image';
 import { usePostDeleteHook } from '../posts/hooks/usePostDeleteHook';
 import { useCommentDeleteHook } from '../comments/hooks/useCommentDeleteHook';
 import { useRecommentDeleteHook } from '../comments/hooks/useRecommentDeleteHook';
 import DeleteModal from './DeleteModal';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { PostEntity } from '../types/post';
 import useRoutings from '@/shared/hooks/useRoutings';
 
-export function UserProfile({ post }: { post: PostEntity }) {
-  const { goProfile } = useRoutings();
-
-  return (
-    <div
-      className="flex w-8 h-7 rounded-lg bg-innerContainerColor justify-center items-center cursor-pointer"
-      onClick={(e) => {
-        e.stopPropagation();
-        goProfile(post.userId);
-      }}
-    >
-      {post.userProfileUrl ? (
-        <div className="relative w-8 h-8">
-          <Image
-            src={post.userProfileUrl}
-            alt="프로필"
-            className="rounded-lg object-cover aspect-square"
-            priority
-            fill
-            sizes="(max-width:480px) 32px, 10vw"
-          />
-        </div>
-      ) : (
-        <User className="text-textColor" width={20} height={20} />
-      )}
-    </div>
-  );
-}
-
-export function UserInfo({ post }: { post: PostEntity }) {
+export default function UserInfo({ post }: { post: PostEntity }) {
   const id = Number(post.id);
   const [isOpen, setOpen] = useState(false);
-  const [isNarrow, setIsNarrow] = useState(false);
   const { deletePostExecute } = usePostDeleteHook({ id });
   const { deleteCommentExecute } = useCommentDeleteHook({ id });
   const { deleteRecommentExecute } = useRecommentDeleteHook({ id });
@@ -60,16 +29,6 @@ export function UserInfo({ post }: { post: PostEntity }) {
     else deleteRecommentExecute();
     closeModal();
   }
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsNarrow(window.innerWidth < 340);
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   return (
     <div className="flex justify-between gap-2">
@@ -92,7 +51,7 @@ export function UserInfo({ post }: { post: PostEntity }) {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex self-center text-xs">
-          {formatDate(post.createdAt, isNarrow)}
+          {formatDate(post.createdAt)}
         </div>
         {post.isMine &&
           (!isOpen ? (

--- a/kakaobase/src/features/feeds/ui/UserProfileImage.tsx
+++ b/kakaobase/src/features/feeds/ui/UserProfileImage.tsx
@@ -1,9 +1,14 @@
 import useRoutings from '@/shared/hooks/useRoutings';
-import { PostEntity } from '../types/post';
 import Image from 'next/image';
 import { User } from 'lucide-react';
 
-export default function UserProfileImage({ post }: { post: PostEntity }) {
+export default function UserProfileImage({
+  id,
+  profileUrl,
+}: {
+  id: number;
+  profileUrl?: string;
+}) {
   const { goProfile } = useRoutings();
 
   return (
@@ -11,13 +16,13 @@ export default function UserProfileImage({ post }: { post: PostEntity }) {
       className="flex w-8 h-7 rounded-lg bg-innerContainerColor justify-center items-center cursor-pointer"
       onClick={(e) => {
         e.stopPropagation();
-        goProfile(post.userId);
+        goProfile(id);
       }}
     >
-      {post.userProfileUrl ? (
+      {profileUrl ? (
         <div className="relative w-8 h-8">
           <Image
-            src={post.userProfileUrl}
+            src={profileUrl}
             alt="프로필"
             className="rounded-lg object-cover aspect-square"
             priority

--- a/kakaobase/src/features/feeds/ui/UserProfileImage.tsx
+++ b/kakaobase/src/features/feeds/ui/UserProfileImage.tsx
@@ -1,0 +1,33 @@
+import useRoutings from '@/shared/hooks/useRoutings';
+import { PostEntity } from '../types/post';
+import Image from 'next/image';
+import { User } from 'lucide-react';
+
+export default function UserProfileImage({ post }: { post: PostEntity }) {
+  const { goProfile } = useRoutings();
+
+  return (
+    <div
+      className="flex w-8 h-7 rounded-lg bg-innerContainerColor justify-center items-center cursor-pointer"
+      onClick={(e) => {
+        e.stopPropagation();
+        goProfile(post.userId);
+      }}
+    >
+      {post.userProfileUrl ? (
+        <div className="relative w-8 h-8">
+          <Image
+            src={post.userProfileUrl}
+            alt="프로필"
+            className="rounded-lg object-cover aspect-square"
+            priority
+            fill
+            sizes="(max-width:480px) 32px, 10vw"
+          />
+        </div>
+      ) : (
+        <User className="text-textColor" width={20} height={20} />
+      )}
+    </div>
+  );
+}

--- a/kakaobase/src/shared/hooks/useRoutings.tsx
+++ b/kakaobase/src/shared/hooks/useRoutings.tsx
@@ -48,6 +48,12 @@ export default function useRoutings() {
   function goEditor() {
     router.push('/post/new');
   }
+  function goUnauthorized() {
+    router.push('/unauthorized');
+  }
+  function goPath(path: string) {
+    router.push(path);
+  }
   return {
     goLogin,
     goHome,
@@ -64,5 +70,7 @@ export default function useRoutings() {
     goMain,
     goLikes,
     goEditor,
+    goUnauthorized,
+    goPath,
   };
 }

--- a/kakaobase/src/widgets/background/Surfing.tsx
+++ b/kakaobase/src/widgets/background/Surfing.tsx
@@ -1,0 +1,13 @@
+import Image from 'next/image';
+
+export default function Surfing() {
+  return (
+    <Image
+      src="/chunsik.png"
+      alt="surfing"
+      fill
+      sizes="(max-width : 1024px) 10vw, 96px"
+      className="surfing object-contain hidden lg:block"
+    />
+  );
+}

--- a/kakaobase/src/widgets/navbar/NavItem.tsx
+++ b/kakaobase/src/widgets/navbar/NavItem.tsx
@@ -1,8 +1,8 @@
 import { useAlarmStore } from '@/features/alarm/stores/alarmStore';
+import useRoutings from '@/shared/hooks/useRoutings';
 import clsx from 'clsx';
 import { Bell, LucideIcon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import { useRouter } from 'next/navigation';
 
 export default function NavItem({
   icon: Icon,
@@ -12,12 +12,12 @@ export default function NavItem({
   path: string;
 }) {
   const pathName = usePathname();
-  const router = useRouter();
   const isActive = pathName === path;
   const { cnt } = useAlarmStore();
+  const { goPath } = useRoutings();
 
   const handleClick = () => {
-    if (path) router.push(path);
+    if (path) goPath(path);
     const sc = document.querySelector<HTMLElement>('[data-scroll-area]');
     if (path.includes('chat')) {
       sc?.scrollTo({ top: sc.scrollHeight, behavior: 'smooth' });

--- a/kakaobase/src/widgets/navbar/NavItemProfile.tsx
+++ b/kakaobase/src/widgets/navbar/NavItemProfile.tsx
@@ -1,22 +1,22 @@
 import Image from 'next/image';
 import NavItem from './NavItem';
 import { User } from 'lucide-react';
-import clsx from 'clsx';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useUserStore } from '@/entities/users/stores/userStore';
+import useRoutings from '@/shared/hooks/useRoutings';
 
 export default function NavItemProfile() {
   const pathName = usePathname();
-  const router = useRouter();
+  const { goPath, goUnauthorized } = useRoutings();
   const { userId, imageUrl } = useUserStore();
   const isActive = pathName.includes('/profile');
   const path = `/profile/${userId}`;
 
   function navMyProfile() {
     if (userId === 0 || !userId) {
-      router.push('/unauthorized');
+      goUnauthorized();
     } else {
-      router.push(path);
+      goPath(path);
     }
     const sc = document.querySelector<HTMLElement>('[data-scroll-area]');
     sc?.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
## 컴포넌트 분리 및 불필요한 부분 제거
- UserInfo -> UserInfo, UserProfileImage
- formatDate 함수 isNarrow 제거
- 관련 false, isNarrow 파라미터 넘기는 부분 제거

## 이전 커밋 import 수정
[PostCard]
- UserProfileImage
- UserInfo

## 라우팅 수정
- useRouter에 라우팅 로직 전부 모음

## 컴포넌트 분리
- 서핑 컴포넌트 분리
- 로컬 이미지 / 캐싱이라 별도 memo 처리는 의미 없음

## 게시글 상세 하단 padding 수정
- 웹에서 댓글이 잘려서 보임

## param, memo
- PostCard에서 UserProfileImage 컴포넌트로 넘기는 props 수정
- 범위를 더 좁힘
- post 전체에서 id, 이미지 url 만 전송
- PostCard memo 처리
- 9.8ms -> 3.5ms : 6.3ms 감소 (약 64% 향상)
- PostList

전체 렌더링 시간 기준 약 25% 감소 (62.8ms → 47.2ms)
PostList 자체 렌더링 시간 : 0.5ms → 0.4ms로 변화 거의 없기에 자식 컴포넌트 리렌더 방지가 핵심.